### PR TITLE
New Boundary Conditions and Fixing Bug in Esirkepov Current Deposition

### DIFF
--- a/PyPIC3D/__main__.py
+++ b/PyPIC3D/__main__.py
@@ -29,7 +29,7 @@ from PyPIC3D.diagnostics.vtk import (
 
 from PyPIC3D.utils import (
     dump_parameters_to_toml, load_config_file, compute_energy,
-    setup_pmd_files
+    setup_pmd_files, add_external_fields
 )
 
 from PyPIC3D.initialization import (
@@ -63,9 +63,11 @@ def run_PyPIC3D(config_file):
     scalar_field_names = ["rho", "mass_density"]
     vector_field_names = ["E", "B", "J"]
 
-    E, B, J, rho, *rest = fields
+    E, B, J, rho, phi, external_fields, *rest = fields
     # unpack the fields
-    e_energy, b_energy, kinetic_energy = compute_energy(particles, E, B, world, constants)
+    total_E, total_B = add_external_fields(E, B, external_fields)
+    # energy diagnostics use the fields seen by the particle pusher
+    e_energy, b_energy, kinetic_energy = compute_energy(particles, total_E, total_B, world, constants)
     # Compute the energy of the system
     initial_energy = e_energy + b_energy + kinetic_energy
 
@@ -85,10 +87,12 @@ def run_PyPIC3D(config_file):
             plot_num = t // plotting_parameters['plotting_interval']
             # determine the plot number
 
-            E, B, J, rho, *rest = fields
+            E, B, J, rho, phi, external_fields, *rest = fields
             # unpack the fields
 
-            e_energy, b_energy, kinetic_energy = compute_energy(particles, E, B, world, constants)
+            total_E, total_B = add_external_fields(E, B, external_fields)
+            # energy diagnostics use the fields seen by the particle pusher
+            e_energy, b_energy, kinetic_energy = compute_energy(particles, total_E, total_B, world, constants)
             # Compute the energy of the system
             write_data(f"{output_dir}/data/total_energy.txt", t * dt, e_energy + b_energy + kinetic_energy)
             write_data(f"{output_dir}/data/energy_error.txt", t * dt, abs( initial_energy - (e_energy + b_energy + kinetic_energy)) / max(initial_energy, 1e-10))
@@ -144,7 +148,7 @@ def run_PyPIC3D(config_file):
                 write_openpmd_fields(fields, world, os.path.join(output_dir, "data"), plot_num, t,  "fields", ".h5")
             # Write the fields in openPMD format
 
-            fields = (E, B, J, rho, *rest)
+            fields = (E, B, J, rho, phi, external_fields, *rest)
             # repack the fields
 
         particles, fields = jit_loop(
@@ -186,10 +190,12 @@ def main():
     end = time.time()
     # end the timer
 
-    E, B, J, *rest = fields
+    E, B, J, rho, phi, external_fields, *rest = fields
     # unpack the fields
 
-    e_energy, b_energy, kinetic_energy = compute_energy(particles, E, B, world, constants)
+    total_E, total_B = add_external_fields(E, B, external_fields)
+    # energy diagnostics use the fields seen by the particle pusher
+    e_energy, b_energy, kinetic_energy = compute_energy(particles, total_E, total_B, world, constants)
     # compute the energy of the system
     print(f"Final Electric Field Energy: {e_energy}")
     print(f"Final Magnetic Field Energy: {b_energy}")

--- a/PyPIC3D/boundary_conditions/PML.py
+++ b/PyPIC3D/boundary_conditions/PML.py
@@ -1,0 +1,218 @@
+import math
+
+import jax.numpy as jnp
+
+from PyPIC3D.boundary_conditions.boundaryconditions import update_ghost_cells
+from PyPIC3D.boundary_conditions.grid_and_stencil import BC_CONDUCTING, BC_PERIODIC
+
+
+PML_WALLS = ["-x", "+x", "-y", "+y", "-z", "+z"]
+
+_AXIS_FOR_WALL = {"-x": "x", "+x": "x", "-y": "y", "+y": "y", "-z": "z", "+z": "z"}
+_AXIS_INDEX = {"x": 0, "y": 1, "z": 2}
+_SPACING_KEY = {"x": "dx", "y": "dy", "z": "dz"}
+_COUNT_KEY = {"x": "Nx", "y": "Ny", "z": "Nz"}
+
+
+def _normalize_raw_pml(raw_pml):
+    if raw_pml is None:
+        return []
+    if isinstance(raw_pml, dict):
+        return [raw_pml]
+    return list(raw_pml)
+
+
+def parse_pml_config(raw_pml, world, constants):
+    """
+    Validate user PML config and return normalized wall layer dictionaries.
+    """
+    entries = []
+    seen = set()
+    for raw in _normalize_raw_pml(raw_pml):
+        wall = raw.get("wall")
+        if wall not in PML_WALLS:
+            raise ValueError(f"Invalid PML wall: {wall}. Expected one of {PML_WALLS}")
+        if wall in seen:
+            raise ValueError(f"Duplicate PML wall: {wall}")
+        seen.add(wall)
+
+        axis = _AXIS_FOR_WALL[wall]
+        active_cells = int(world[_COUNT_KEY[axis]])
+        thickness = int(raw.get("thickness", 0))
+        if thickness <= 0:
+            raise ValueError(f"PML thickness for {wall} must be positive")
+        if thickness > active_cells:
+            raise ValueError(
+                f"PML thickness for {wall} exceeds active cells on {axis}: {thickness} > {active_cells}"
+            )
+
+        order = float(raw.get("order", 3.0))
+        if order <= 0.0:
+            raise ValueError(f"PML order for {wall} must be positive")
+
+        target_reflection = float(raw.get("target_reflection", 1e-8))
+        if target_reflection <= 0.0 or target_reflection >= 1.0:
+            raise ValueError(f"PML target_reflection for {wall} must be between 0 and 1")
+
+        if "sigma_max" in raw:
+            sigma_max = float(raw["sigma_max"])
+        else:
+            layer_width = thickness * float(world[_SPACING_KEY[axis]])
+            sigma_max = -((order + 1.0) * float(constants["C"]) * math.log(target_reflection)) / (
+                2.0 * layer_width
+            )
+        if sigma_max <= 0.0:
+            raise ValueError(f"PML sigma_max for {wall} must be positive")
+
+        entries.append(
+            {
+                "wall": wall,
+                "axis": axis,
+                "thickness": thickness,
+                "order": order,
+                "target_reflection": target_reflection,
+                "sigma_max": sigma_max,
+            }
+        )
+    return entries
+
+
+def _ghost_shape(world):
+    return (int(world["Nx"]) + 2, int(world["Ny"]) + 2, int(world["Nz"]) + 2)
+
+
+def build_pml_profiles(world, pml_layers):
+    """
+    Build ghost-celled sigma profiles for x, y, and z derivative directions.
+    """
+    shape = _ghost_shape(world)
+    profiles = {
+        "sigma_x": jnp.zeros(shape),
+        "sigma_y": jnp.zeros(shape),
+        "sigma_z": jnp.zeros(shape),
+    }
+
+    for layer in pml_layers:
+        wall = layer["wall"]
+        axis = layer["axis"]
+        axis_index = _AXIS_INDEX[axis]
+        sigma_name = f"sigma_{axis}"
+        thickness = int(layer["thickness"])
+        order = float(layer["order"])
+        sigma_max = float(layer["sigma_max"])
+
+        for i in range(thickness):
+            ramp = sigma_max * ((i + 1) / thickness) ** order
+            index = 1 + i if wall[0] == "-" else shape[axis_index] - 2 - (thickness - 1 - i)
+            slices = [slice(None), slice(None), slice(None)]
+            slices[axis_index] = index
+            profiles[sigma_name] = profiles[sigma_name].at[tuple(slices)].set(ramp)
+
+    return profiles
+
+
+def _zero_like_profiles(world):
+    shape = _ghost_shape(world)
+    return {
+        "sigma_x": jnp.zeros(shape),
+        "sigma_y": jnp.zeros(shape),
+        "sigma_z": jnp.zeros(shape),
+    }
+
+
+def build_pml_metadata(raw_pml, world, constants):
+    layers = parse_pml_config(raw_pml, world, constants)
+    pml_axes = {
+        "x": any(layer["axis"] == "x" for layer in layers),
+        "y": any(layer["axis"] == "y" for layer in layers),
+        "z": any(layer["axis"] == "z" for layer in layers),
+    }
+    return {
+        "active": bool(layers),
+        "pml_x": pml_axes["x"],
+        "pml_y": pml_axes["y"],
+        "pml_z": pml_axes["z"],
+        "profiles": build_pml_profiles(world, layers) if layers else _zero_like_profiles(world),
+    }
+
+
+def _zeros_for_terms(world, names):
+    shape = (int(world["Nx"]), int(world["Ny"]), int(world["Nz"]))
+    return {name: jnp.zeros(shape) for name in names}
+
+
+def initialize_pml_state(world):
+    """
+    Return zero-valued auxiliary source memory for PML derivative terms.
+    """
+    e_terms = ("dBz_dy", "dBy_dz", "dBx_dz", "dBz_dx", "dBy_dx", "dBx_dy")
+    b_terms = ("dEz_dy", "dEy_dz", "dEx_dz", "dEz_dx", "dEy_dx", "dEx_dy")
+    return {"E": _zeros_for_terms(world, e_terms), "B": _zeros_for_terms(world, b_terms)}
+
+
+def has_pml(world):
+    pml = world.get("pml", None)
+    return bool(pml is not None and pml.get("active", False))
+
+
+def _sigma_for_term(world, term):
+    profiles = world["pml"]["profiles"]
+    if term.endswith("_dx"):
+        return profiles["sigma_x"][1:-1, 1:-1, 1:-1]
+    if term.endswith("_dy"):
+        return profiles["sigma_y"][1:-1, 1:-1, 1:-1]
+    if term.endswith("_dz"):
+        return profiles["sigma_z"][1:-1, 1:-1, 1:-1]
+    raise ValueError(f"Unsupported PML derivative term: {term}")
+
+
+def _apply_auxiliary_source(derivative, memory, sigma, dt):
+    b = jnp.exp(-sigma * dt)
+    memory_new = b * memory + (b - 1.0) * derivative
+    return derivative + memory_new, memory_new
+
+
+def apply_pml_to_e_curl(derivatives, world, pml_state):
+    dt = world["dt"]
+    memory = pml_state["E"]
+    corrected = {}
+    memory_new = {}
+    for name, derivative in derivatives.items():
+        corrected[name], memory_new[name] = _apply_auxiliary_source(
+            derivative, memory[name], _sigma_for_term(world, name), dt
+        )
+
+    curl_x = corrected["dBz_dy"] - corrected["dBy_dz"]
+    curl_y = corrected["dBx_dz"] - corrected["dBz_dx"]
+    curl_z = corrected["dBy_dx"] - corrected["dBx_dy"]
+    return (curl_x, curl_y, curl_z), {"E": memory_new, "B": pml_state["B"]}
+
+
+def apply_pml_to_b_curl(derivatives, world, pml_state):
+    dt = world["dt"]
+    memory = pml_state["B"]
+    corrected = {}
+    memory_new = {}
+    for name, derivative in derivatives.items():
+        corrected[name], memory_new[name] = _apply_auxiliary_source(
+            derivative, memory[name], _sigma_for_term(world, name), dt
+        )
+
+    curl_x = corrected["dEz_dy"] - corrected["dEy_dz"]
+    curl_y = corrected["dEx_dz"] - corrected["dEz_dx"]
+    curl_z = corrected["dEy_dx"] - corrected["dEx_dy"]
+    return (curl_x, curl_y, curl_z), {"E": pml_state["E"], "B": memory_new}
+
+
+def update_ghost_cells_for_pml(field, world):
+    """
+    Fill ghost cells while suppressing periodic wrap on axes that contain PML.
+    """
+    bc_x = world["boundary_conditions"]["x"]
+    bc_y = world["boundary_conditions"]["y"]
+    bc_z = world["boundary_conditions"]["z"]
+    pml = world["pml"]
+    bc_x = jnp.where((pml["pml_x"]) & (bc_x == BC_PERIODIC), BC_CONDUCTING, bc_x)
+    bc_y = jnp.where((pml["pml_y"]) & (bc_y == BC_PERIODIC), BC_CONDUCTING, bc_y)
+    bc_z = jnp.where((pml["pml_z"]) & (bc_z == BC_PERIODIC), BC_CONDUCTING, bc_z)
+    return update_ghost_cells(field, bc_x, bc_y, bc_z)

--- a/PyPIC3D/boundary_conditions/PML.py
+++ b/PyPIC3D/boundary_conditions/PML.py
@@ -14,31 +14,34 @@ _SPACING_KEY = {"x": "dx", "y": "dy", "z": "dz"}
 _COUNT_KEY = {"x": "Nx", "y": "Ny", "z": "Nz"}
 
 
-def _normalize_raw_pml(raw_pml):
-    if raw_pml is None:
-        return []
-    if isinstance(raw_pml, dict):
-        return [raw_pml]
-    return list(raw_pml)
-
-
-def parse_pml_config(raw_pml, world, constants):
+def load_pml_from_toml(raw_pml, world, constants):
     """
-    Validate user PML config and return normalized wall layer dictionaries.
+    Read PML wall layers from TOML-style config and build the stretch profiles.
+
+    The returned tuple is
+
+        active, pml_x, pml_y, pml_z, profiles
+
+    where `profiles = (sigma_x, sigma_y, sigma_z)`.  The layer tuples built here
+    are kept local because callers only need the finished coordinate-stretch
+    profiles, not a second configuration object.
     """
-    entries = []
-    seen = set()
-    for raw in _normalize_raw_pml(raw_pml):
+    raw_layers = [] if raw_pml is None else raw_pml
+    raw_layers = [raw_layers] if isinstance(raw_layers, dict) else list(raw_layers)
+
+    pml_layers = []
+    seen_walls = set()
+    for raw in raw_layers:
         wall = raw.get("wall")
         if wall not in PML_WALLS:
             raise ValueError(f"Invalid PML wall: {wall}. Expected one of {PML_WALLS}")
-        if wall in seen:
+        if wall in seen_walls:
             raise ValueError(f"Duplicate PML wall: {wall}")
-        seen.add(wall)
+        seen_walls.add(wall)
 
         axis = _AXIS_FOR_WALL[wall]
-        active_cells = int(world[_COUNT_KEY[axis]])
         thickness = int(raw.get("thickness", 0))
+        active_cells = int(world[_COUNT_KEY[axis]])
         if thickness <= 0:
             raise ValueError(f"PML thickness for {wall} must be positive")
         if thickness > active_cells:
@@ -47,13 +50,7 @@ def parse_pml_config(raw_pml, world, constants):
             )
 
         order = float(raw.get("order", 3.0))
-        if order <= 0.0:
-            raise ValueError(f"PML order for {wall} must be positive")
-
-        target_reflection = float(raw.get("target_reflection", 1e-8))
-        if target_reflection <= 0.0 or target_reflection >= 1.0:
-            raise ValueError(f"PML target_reflection for {wall} must be between 0 and 1")
-
+        target_reflection = float(raw.get("target_reflection", 1.0e-8))
         if "sigma_max" in raw:
             sigma_max = float(raw["sigma_max"])
         else:
@@ -61,158 +58,212 @@ def parse_pml_config(raw_pml, world, constants):
             sigma_max = -((order + 1.0) * float(constants["C"]) * math.log(target_reflection)) / (
                 2.0 * layer_width
             )
-        if sigma_max <= 0.0:
-            raise ValueError(f"PML sigma_max for {wall} must be positive")
 
-        entries.append(
-            {
-                "wall": wall,
-                "axis": axis,
-                "thickness": thickness,
-                "order": order,
-                "target_reflection": target_reflection,
-                "sigma_max": sigma_max,
-            }
-        )
-    return entries
+        pml_layers.append((wall, axis, thickness, order, sigma_max))
+
+    pml_x = any(axis == "x" for _, axis, _, _, _ in pml_layers)
+    pml_y = any(axis == "y" for _, axis, _, _, _ in pml_layers)
+    pml_z = any(axis == "z" for _, axis, _, _, _ in pml_layers)
+
+    return bool(pml_layers), pml_x, pml_y, pml_z, build_pml(world, tuple(pml_layers))
 
 
-def _ghost_shape(world):
-    return (int(world["Nx"]) + 2, int(world["Ny"]) + 2, int(world["Nz"]) + 2)
-
-
-def build_pml_profiles(world, pml_layers):
+def build_pml(world, pml_layers):
     """
-    Build ghost-celled sigma profiles for x, y, and z derivative directions.
-    """
-    shape = _ghost_shape(world)
-    profiles = {
-        "sigma_x": jnp.zeros(shape),
-        "sigma_y": jnp.zeros(shape),
-        "sigma_z": jnp.zeros(shape),
-    }
+    Build ghost-celled damping profiles for the coordinate stretch.
 
-    for layer in pml_layers:
-        wall = layer["wall"]
-        axis = layer["axis"]
+    `sigma_x`, `sigma_y`, and `sigma_z` are the real damping strengths in the
+    frequency-space stretch factors.  The ramp is weak at the interface with the
+    physical domain and grows toward the outer wall, so the outgoing wave sees a
+    gradual coordinate stretch rather than a sharp jump.
+    """
+    shape = (int(world["Nx"]) + 2, int(world["Ny"]) + 2, int(world["Nz"]) + 2)
+
+    sigma_x = jnp.zeros(shape)
+    sigma_y = jnp.zeros(shape)
+    sigma_z = jnp.zeros(shape)
+    profiles = (sigma_x, sigma_y, sigma_z)
+
+    for wall, axis, thickness, order, sigma_max in pml_layers:
         axis_index = _AXIS_INDEX[axis]
-        sigma_name = f"sigma_{axis}"
-        thickness = int(layer["thickness"])
-        order = float(layer["order"])
-        sigma_max = float(layer["sigma_max"])
+        profile_index = _AXIS_INDEX[axis]
+        sigma_profile = profiles[profile_index]
 
-        for i in range(thickness):
-            ramp = sigma_max * ((i + 1) / thickness) ** order
-            index = 1 + i if wall[0] == "-" else shape[axis_index] - 2 - (thickness - 1 - i)
+        for i in range(int(thickness)):
+            sigma = float(sigma_max) * ((i + 1) / int(thickness)) ** float(order)
+            if wall[0] == "-":
+                index = int(thickness) - i
+            else:
+                index = shape[axis_index] - 1 - int(thickness) + i
+
             slices = [slice(None), slice(None), slice(None)]
             slices[axis_index] = index
-            profiles[sigma_name] = profiles[sigma_name].at[tuple(slices)].set(ramp)
+            sigma_profile = sigma_profile.at[tuple(slices)].set(sigma)
+
+        profiles = profiles[:profile_index] + (sigma_profile,) + profiles[profile_index + 1 :]
 
     return profiles
 
 
-def _zero_like_profiles(world):
-    shape = _ghost_shape(world)
-    return {
-        "sigma_x": jnp.zeros(shape),
-        "sigma_y": jnp.zeros(shape),
-        "sigma_z": jnp.zeros(shape),
-    }
-
-
-def build_pml_metadata(raw_pml, world, constants):
-    layers = parse_pml_config(raw_pml, world, constants)
-    pml_axes = {
-        "x": any(layer["axis"] == "x" for layer in layers),
-        "y": any(layer["axis"] == "y" for layer in layers),
-        "z": any(layer["axis"] == "z" for layer in layers),
-    }
-    return {
-        "active": bool(layers),
-        "pml_x": pml_axes["x"],
-        "pml_y": pml_axes["y"],
-        "pml_z": pml_axes["z"],
-        "profiles": build_pml_profiles(world, layers) if layers else _zero_like_profiles(world),
-    }
-
-
-def _zeros_for_terms(world, names):
-    shape = (int(world["Nx"]), int(world["Ny"]), int(world["Nz"]))
-    return {name: jnp.zeros(shape) for name in names}
-
-
 def initialize_pml_state(world):
     """
-    Return zero-valued auxiliary source memory for PML derivative terms.
+    Allocate ADE memory for stretched derivatives.
+
+    `pml_state = (E_memory, B_memory)`.
+
+    E_memory stores B-derivative history in this order:
+        dBz_dy, dBy_dz, dBx_dz, dBz_dx, dBy_dx, dBx_dy
+
+    B_memory stores E-derivative history in this order:
+        dEz_dy, dEy_dz, dEx_dz, dEz_dx, dEy_dx, dEx_dy
+
+    Each memory array has physical-interior shape `(Nx, Ny, Nz)`, matching the
+    finite-difference arrays that enter the Yee curl.
     """
-    e_terms = ("dBz_dy", "dBy_dz", "dBx_dz", "dBz_dx", "dBy_dx", "dBx_dy")
-    b_terms = ("dEz_dy", "dEy_dz", "dEx_dz", "dEz_dx", "dEy_dx", "dEx_dy")
-    return {"E": _zeros_for_terms(world, e_terms), "B": _zeros_for_terms(world, b_terms)}
+    shape = (int(world["Nx"]), int(world["Ny"]), int(world["Nz"]))
+
+    e_memory = tuple(jnp.zeros(shape) for _ in range(6))
+    b_memory = tuple(jnp.zeros(shape) for _ in range(6))
+
+    return e_memory, b_memory
 
 
-def has_pml(world):
-    pml = world.get("pml", None)
-    return bool(pml is not None and pml.get("active", False))
+def stretch_spatial_derivative(derivative, memory, sigma, dt):
+    """
+    Apply one coordinate-stretched PML derivative.
 
+    In frequency space, a PML is a complex coordinate stretch.  For an x
+    derivative,
 
-def _sigma_for_term(world, term):
-    profiles = world["pml"]["profiles"]
-    if term.endswith("_dx"):
-        return profiles["sigma_x"][1:-1, 1:-1, 1:-1]
-    if term.endswith("_dy"):
-        return profiles["sigma_y"][1:-1, 1:-1, 1:-1]
-    if term.endswith("_dz"):
-        return profiles["sigma_z"][1:-1, 1:-1, 1:-1]
-    raise ValueError(f"Unsupported PML derivative term: {term}")
+        d_dx -> (1 / sigma(w)) d_dx
 
-
-def _apply_auxiliary_source(derivative, memory, sigma, dt):
+    where `sigma(w)` is the frequency-domain stretch factor.  Equivalently,
+    one often writes `s_x(w) = 1 + sigma_x / (i w)`, so the derivative becomes
+    `(1 / s_x) d_dx`.  The real array `sigma` below is the local damping profile
+    inside the PML.  The memory term is the time-domain bookkeeping that applies
+    this stretched derivative without storing the whole field history.
+    """
     b = jnp.exp(-sigma * dt)
     memory_new = b * memory + (b - 1.0) * derivative
     return derivative + memory_new, memory_new
 
 
 def apply_pml_to_e_curl(derivatives, world, pml_state):
-    dt = world["dt"]
-    memory = pml_state["E"]
-    corrected = {}
-    memory_new = {}
-    for name, derivative in derivatives.items():
-        corrected[name], memory_new[name] = _apply_auxiliary_source(
-            derivative, memory[name], _sigma_for_term(world, name), dt
-        )
+    """
+    Stretch the B derivatives before assembling the curl used in Ampere's law.
+    """
+    dBz_dy, dBy_dz, dBx_dz, dBz_dx, dBy_dx, dBx_dy = derivatives
+    # The PML state is (E_memory, B_memory), but the E curl only needs the B memory.
+    e_memory, b_memory = pml_state
+    (
+        memory_dBz_dy,
+        memory_dBy_dz,
+        memory_dBx_dz,
+        memory_dBz_dx,
+        memory_dBy_dx,
+        memory_dBx_dy,
+    ) = e_memory
+    # unpack the memory in the same order as the derivatives, so we can apply stretch_spatial_derivative
 
-    curl_x = corrected["dBz_dy"] - corrected["dBy_dz"]
-    curl_y = corrected["dBx_dz"] - corrected["dBz_dx"]
-    curl_z = corrected["dBy_dx"] - corrected["dBx_dy"]
-    return (curl_x, curl_y, curl_z), {"E": memory_new, "B": pml_state["B"]}
+    _, _, _, _, profiles = world["pml"]
+    sigma_x, sigma_y, sigma_z = profiles
+    sigma_x = sigma_x[1:-1, 1:-1, 1:-1]
+    sigma_y = sigma_y[1:-1, 1:-1, 1:-1]
+    sigma_z = sigma_z[1:-1, 1:-1, 1:-1]
+    dt = world["dt"]
+    # unpack the profiles and select only interior cells (no ghost cells)
+
+    dBz_dy, memory_dBz_dy = stretch_spatial_derivative(dBz_dy, memory_dBz_dy, sigma_y, dt)
+    dBy_dz, memory_dBy_dz = stretch_spatial_derivative(dBy_dz, memory_dBy_dz, sigma_z, dt)
+    dBx_dz, memory_dBx_dz = stretch_spatial_derivative(dBx_dz, memory_dBx_dz, sigma_z, dt)
+    dBz_dx, memory_dBz_dx = stretch_spatial_derivative(dBz_dx, memory_dBz_dx, sigma_x, dt)
+    dBy_dx, memory_dBy_dx = stretch_spatial_derivative(dBy_dx, memory_dBy_dx, sigma_x, dt)
+    dBx_dy, memory_dBx_dy = stretch_spatial_derivative(dBx_dy, memory_dBx_dy, sigma_y, dt)
+    # apply the stretch to each derivative and update the memory
+
+    curl_x = dBz_dy - dBy_dz
+    curl_y = dBx_dz - dBz_dx
+    curl_z = dBy_dx - dBx_dy
+    # assemble the curl from the stretched derivatives
+
+    e_memory = (
+        memory_dBz_dy,
+        memory_dBy_dz,
+        memory_dBx_dz,
+        memory_dBz_dx,
+        memory_dBy_dx,
+        memory_dBx_dy,
+    )
+    # pack the updated memory in the same order as the derivatives
+
+    return (curl_x, curl_y, curl_z), (e_memory, b_memory)
+    # return the curl and the updated PML state (with the new E memory and unchanged B memory)
 
 
 def apply_pml_to_b_curl(derivatives, world, pml_state):
-    dt = world["dt"]
-    memory = pml_state["B"]
-    corrected = {}
-    memory_new = {}
-    for name, derivative in derivatives.items():
-        corrected[name], memory_new[name] = _apply_auxiliary_source(
-            derivative, memory[name], _sigma_for_term(world, name), dt
-        )
+    """
+    Stretch the E derivatives before assembling the curl used in Faraday's law.
+    """
+    dEz_dy, dEy_dz, dEx_dz, dEz_dx, dEy_dx, dEx_dy = derivatives
+    e_memory, b_memory = pml_state
+    (
+        memory_dEz_dy,
+        memory_dEy_dz,
+        memory_dEx_dz,
+        memory_dEz_dx,
+        memory_dEy_dx,
+        memory_dEx_dy,
+    ) = b_memory
+    # unpack the memory in the same order as the derivatives, so we can apply stretch_spatial_derivative
 
-    curl_x = corrected["dEz_dy"] - corrected["dEy_dz"]
-    curl_y = corrected["dEx_dz"] - corrected["dEz_dx"]
-    curl_z = corrected["dEy_dx"] - corrected["dEx_dy"]
-    return (curl_x, curl_y, curl_z), {"E": pml_state["E"], "B": memory_new}
+    _, _, _, _, profiles = world["pml"]
+    sigma_x, sigma_y, sigma_z = profiles
+    sigma_x = sigma_x[1:-1, 1:-1, 1:-1]
+    sigma_y = sigma_y[1:-1, 1:-1, 1:-1]
+    sigma_z = sigma_z[1:-1, 1:-1, 1:-1]
+    dt = world["dt"]
+    # unpack the profiles and select only interior cells (no ghost cells)
+
+    dEz_dy, memory_dEz_dy = stretch_spatial_derivative(dEz_dy, memory_dEz_dy, sigma_y, dt)
+    dEy_dz, memory_dEy_dz = stretch_spatial_derivative(dEy_dz, memory_dEy_dz, sigma_z, dt)
+    dEx_dz, memory_dEx_dz = stretch_spatial_derivative(dEx_dz, memory_dEx_dz, sigma_z, dt)
+    dEz_dx, memory_dEz_dx = stretch_spatial_derivative(dEz_dx, memory_dEz_dx, sigma_x, dt)
+    dEy_dx, memory_dEy_dx = stretch_spatial_derivative(dEy_dx, memory_dEy_dx, sigma_x, dt)
+    dEx_dy, memory_dEx_dy = stretch_spatial_derivative(dEx_dy, memory_dEx_dy, sigma_y, dt)
+    # apply the stretch to each derivative and update the memory
+
+    curl_x = dEz_dy - dEy_dz
+    curl_y = dEx_dz - dEz_dx
+    curl_z = dEy_dx - dEx_dy
+    # assemble the curl from the stretched derivatives
+
+    b_memory = (
+        memory_dEz_dy,
+        memory_dEy_dz,
+        memory_dEx_dz,
+        memory_dEz_dx,
+        memory_dEy_dx,
+        memory_dEx_dy,
+    )
+
+    return (curl_x, curl_y, curl_z), (e_memory, b_memory)
 
 
 def update_ghost_cells_for_pml(field, world):
     """
-    Fill ghost cells while suppressing periodic wrap on axes that contain PML.
+    Fill ghost cells without periodically wrapping across a PML wall.
+
+    The PML damping happens in the stretched derivatives above.  This ghost-cell
+    rule only prevents a periodic stencil from feeding a wave back through the
+    opposite side of a PML-active axis.
     """
     bc_x = world["boundary_conditions"]["x"]
     bc_y = world["boundary_conditions"]["y"]
     bc_z = world["boundary_conditions"]["z"]
-    pml = world["pml"]
-    bc_x = jnp.where((pml["pml_x"]) & (bc_x == BC_PERIODIC), BC_CONDUCTING, bc_x)
-    bc_y = jnp.where((pml["pml_y"]) & (bc_y == BC_PERIODIC), BC_CONDUCTING, bc_y)
-    bc_z = jnp.where((pml["pml_z"]) & (bc_z == BC_PERIODIC), BC_CONDUCTING, bc_z)
+    _, pml_x, pml_y, pml_z, _ = world["pml"]
+
+    bc_x = jnp.where((pml_x) & (bc_x == BC_PERIODIC), BC_CONDUCTING, bc_x)
+    bc_y = jnp.where((pml_y) & (bc_y == BC_PERIODIC), BC_CONDUCTING, bc_y)
+    bc_z = jnp.where((pml_z) & (bc_z == BC_PERIODIC), BC_CONDUCTING, bc_z)
+
     return update_ghost_cells(field, bc_x, bc_y, bc_z)

--- a/PyPIC3D/deposition/Esirkepov.py
+++ b/PyPIC3D/deposition/Esirkepov.py
@@ -7,16 +7,14 @@ from jax import lax
 from PyPIC3D.boundary_conditions.grid_and_stencil import (
     BC_PERIODIC,
     axis_has_active_cells,
-    build_axis_stencil_points,
     compute_particle_anchor,
-    inactive_axis_index,
     particle_axis_offset,
 )
-from PyPIC3D.boundary_conditions.boundaryconditions import fold_ghost_cells, update_ghost_cells
+from PyPIC3D.boundary_conditions.boundaryconditions import update_ghost_cells
 from PyPIC3D.deposition.shapes import get_first_order_weights, get_second_order_weights
 
 
-def _roll_old_weights_to_new_frame(old_w_list, shift):
+def shift_old_stencil(old_w_list, shift):
     """Roll old weights into the new-cell frame for Esirkepov deposition."""
     old_w = jnp.stack(old_w_list, axis=0)
 
@@ -27,35 +25,146 @@ def _roll_old_weights_to_new_frame(old_w_list, shift):
     return [rolled[i, :] for i in range(5)]
 
 
-def _collapse_esirkepov_axis(points, current_weights, old_weights, axis_size):
-    """Collapse a ghost-celled singleton axis onto its physical interior cell."""
-    if axis_has_active_cells(axis_size, ghost_cells=True):
+def collapse_redundant_axis(points, current_weights, old_weights, axis_active, extended_axis_size):
+    """Collapse a singleton axis onto the physical cell of the two-ghost buffer."""
+    if axis_active:
         return points, current_weights, old_weights
 
-    collapsed_index = inactive_axis_index(axis_size, ghost_cells=True)
+    collapsed_index = extended_axis_size // 2
+    # the physical cell is the middle point of the extended axis, which has two ghost cells on either side.
     zero = jnp.zeros_like(current_weights[0])
+    # initialize a zero array for padding the weights after collapsing the axis
     current_total = sum(current_weights)
+    # sum the current weights along the collapsed axis to preserve the total current contribution of the particle
     old_total = sum(old_weights)
+    # sum the old weights along the collapsed axis to preserve the total old weight for differencing in Esirkepov's formula
     collapsed_points = jnp.full(points.shape, collapsed_index, dtype=points.dtype)
     collapsed_current = [zero, zero, current_total, zero, zero]
     collapsed_old = [zero, zero, old_total, zero, zero]
+    # build the 5 point stencil with the total weights at the physical cell and zeros at the redundant ghost points.
     return collapsed_points, collapsed_current, collapsed_old
 
 
-def _remap_staggered_periodic_ghosts(points, position, axis_size, wind):
-    """Route out-of-domain staggered Esirkepov stencils into the ghost across the seam."""
-    points = jnp.where(
-        position[jnp.newaxis, ...] > 0.5 * wind,
-        jnp.where(points == axis_size - 1, 0, points),
-        points,
-    )
-    points = jnp.where(
-        position[jnp.newaxis, ...] < -0.5 * wind,
-        jnp.where(points == 0, axis_size - 1, points),
-        points,
-    )
-    return points
+def clear_ghost_cells(field, axis):
+    """Clear the two ghost layers along one axis."""
+    field_axis = jnp.moveaxis(field, axis, 0)
+    # move the axis to be cleared to the front for easier indexing
+    field_axis = field_axis.at[0, :, :].set(0.0)
+    field_axis = field_axis.at[1, :, :].set(0.0)
+    field_axis = field_axis.at[-2, :, :].set(0.0)
+    field_axis = field_axis.at[-1, :, :].set(0.0)
+    # clear the two ghost layers by setting them to zero
+    field = jnp.moveaxis(field_axis, 0, axis)
+    # move the axis back to its original position
+    return field
 
+
+def enforce_bc_along_axis(field, axis, bc, component_axis):
+    """
+    Enforce boundary conditions along a specified axis of a field array.
+    
+    This function applies boundary conditions to ghost cells of a field by moving
+    the specified axis to the front for easier manipulation, applying the appropriate
+    boundary condition logic, and then moving the axis back to its original position.
+    
+    Parameters
+    ----------
+    field : jax.Array
+        The field array to which boundary conditions will be applied.
+        Expected to have two ghost cells at indices 0, 1, -2, -1 along the specified axis.
+    axis : int
+        The axis along which to enforce boundary conditions (0, 1, or 2).
+    bc : str
+        The type of boundary condition to apply. Options are:
+        - "reflecting": Ghost cells are reflected across the boundary with optional sign flip
+        - "absorbing": Ghost cells are left unchanged (will be cleared afterward)
+        - "periodic": Ghost cells are folded by adding them to opposite physical layers (default)
+    component_axis : int
+        The axis corresponding to the field component direction. Used to determine
+        the sign for reflecting boundary conditions (sign = -1 if axis == component_axis,
+        else 1).
+    
+    Returns
+    -------
+    jax.Array
+        The field array with boundary conditions enforced and ghost cells cleared.
+    
+    Notes
+    -----
+    - Ghost cells are assumed to be at indices [0, 1, -2, -1] along the axis.
+    - The extended physical region is at indices [2:-2] along the axis.
+    - After applying boundary conditions, all ghost cells are cleared to zero.
+    """
+
+
+    field_axis = jnp.moveaxis(field, axis, 0)
+    # move the axis to be folded to the front for easier indexing.
+
+    if bc == "reflecting":
+        sign = -1.0 if axis == component_axis else 1.0
+        field_axis = field_axis.at[2, :, :].add(sign * field_axis[0, :, :])
+        field_axis = field_axis.at[3, :, :].add(sign * field_axis[1, :, :])
+        field_axis = field_axis.at[-4, :, :].add(sign * field_axis[-2, :, :])
+        field_axis = field_axis.at[-3, :, :].add(sign * field_axis[-1, :, :])
+        # if the boundary is reflecting, then reflect the ghost layers across the boundary
+    elif bc == "absorbing":
+        field_axis = field_axis
+        # if the boundary is absorbing, then neglect the ghost layers by leaving them as they are, which will be cleared to zero in the next step.
+    else:
+        # PERIODIC BC IS THE DEFAULT
+        field_axis = field_axis.at[-4, :, :].add(field_axis[0, :, :])
+        field_axis = field_axis.at[-3, :, :].add(field_axis[1, :, :])
+        field_axis = field_axis.at[2, :, :].add(field_axis[-2, :, :])
+        field_axis = field_axis.at[3, :, :].add(field_axis[-1, :, :])
+        # if the boundary is periodic, fold the ghost layers by adding them to the opposite physical layer.
+
+
+    field = jnp.moveaxis(field_axis, 0, axis)
+    # move the axis back to its original position after folding the ghost layers according to the boundary condition.
+    field = clear_ghost_cells(field, axis)
+    # clear the ghost cells
+
+    return field
+
+def ghost_cell_bc_esirkepov(field, bc_x, bc_y, bc_z, component_axis):
+    """
+    Apply boundary conditions to ghost cells using Esirkepov method.
+
+    Enforces boundary conditions along all three axes (x, y, z) for a field
+    by applying the appropriate boundary condition type along each spatial dimension.
+
+    Parameters
+    ----------
+    field : ndarray
+        The field array to which boundary conditions will be applied.
+    bc_x : str or callable
+        Boundary condition to enforce along the x-axis (axis=0).
+    bc_y : str or callable
+        Boundary condition to enforce along the y-axis (axis=1).
+    bc_z : str or callable
+        Boundary condition to enforce along the z-axis (axis=2).
+    component_axis : int
+        The axis index of the field component for which boundary conditions
+        are being applied.
+
+    Returns
+    -------
+    ndarray
+        The field array with boundary conditions applied along all three axes.
+    """
+    field = enforce_bc_along_axis(field, axis=0, bc=bc_x, component_axis=component_axis)
+    # enforce the x boundary conditions along the x axis (axis=0)
+    field = enforce_bc_along_axis(field, axis=1, bc=bc_y, component_axis=component_axis)
+    # enforce the y boundary conditions along the y axis (axis=1)
+    field = enforce_bc_along_axis(field, axis=2, bc=bc_z, component_axis=component_axis)
+    # enforce the z boundary conditions along the z axis (axis=2)
+    return field
+
+
+def eliminate_esirkepov_ghost_cells(field):
+    slices = [slice(1, -1), slice(1, -1), slice(1, -1)]
+    # remove one layer on each side, returning the solver's ordinary one-ghost current array.
+    return field[tuple(slices)]
 
 def Esirkepov_current(particles, J, constants, world, grid=None, filter=None):
     """Esirkepov current deposition supporting 1D/2D/3D via inactive dims."""
@@ -65,7 +174,6 @@ def Esirkepov_current(particles, J, constants, world, grid=None, filter=None):
     Jx, Jy, Jz = J
     Nx, Ny, Nz = Jx.shape
     dx, dy, dz, dt = world["dx"], world["dy"], world["dz"], world["dt"]
-    xmin, ymin, zmin = grid[0][0], grid[1][0], grid[2][0]
     bc_x = world["boundary_conditions"]["x"]
     bc_y = world["boundary_conditions"]["y"]
     bc_z = world["boundary_conditions"]["z"]
@@ -79,7 +187,26 @@ def Esirkepov_current(particles, J, constants, world, grid=None, filter=None):
     z_active = axis_has_active_cells(Nz, ghost_cells=True)
     # determine which directions are not quasi-1D.
 
+    Nx_ext, Ny_ext, Nz_ext = Nx + 2, Ny + 2, Nz + 2
+    # calculate the size of the extended grid with two ghost layers on each side for Esirkepov deposition.
+
+    x_extended = jnp.concatenate([ grid[0][:1] - dx, grid[0], grid[0][-1:] + dx,])
+    # add +- dx ghost points to the x grid axis for an extra ghost cell on each side
+    y_extended = jnp.concatenate([ grid[1][:1] - dy, grid[1], grid[1][-1:] + dy,])
+    # add +- dy ghost points to the y grid axis for an extra ghost cell on each side
+    z_extended = jnp.concatenate([ grid[2][:1] - dz, grid[2], grid[2][-1:] + dz,])
+    # add +- dz ghost points to the z grid axis for an extra ghost cell on each side
+
+    extended_grid = (x_extended, y_extended, z_extended)
+    # build the extended grid tuple for passing to deposition functions
+
     for species in particles:
+        Jx_ext = jnp.zeros((Nx_ext, Ny_ext, Nz_ext), dtype=Jx.dtype)
+        Jy_ext = jnp.zeros_like(Jx_ext)
+        Jz_ext = jnp.zeros_like(Jx_ext)
+        # Deposit one species at a time so particle boundary labels can fold
+        # the extended ghost layers correctly.
+
         q = species.get_charge()
         x, y, z = species.get_forward_position()
         vx, vy, vz = species.get_velocity()
@@ -93,22 +220,22 @@ def Esirkepov_current(particles, J, constants, world, grid=None, filter=None):
         old_z = z - vz * dt
         # compute old positions by backstepping along the velocity
 
-        x0 = compute_particle_anchor(x, grid[0], shape_factor)
-        y0 = compute_particle_anchor(y, grid[1], shape_factor)
-        z0 = compute_particle_anchor(z, grid[2], shape_factor)
+        x0 = compute_particle_anchor(x, extended_grid[0], shape_factor)
+        y0 = compute_particle_anchor(y, extended_grid[1], shape_factor)
+        z0 = compute_particle_anchor(z, extended_grid[2], shape_factor)
         # compute the nearest grid point to the particle's current position
 
-        old_x0 = compute_particle_anchor(old_x, grid[0], shape_factor)
-        old_y0 = compute_particle_anchor(old_y, grid[1], shape_factor)
-        old_z0 = compute_particle_anchor(old_z, grid[2], shape_factor)
+        old_x0 = compute_particle_anchor(old_x, extended_grid[0], shape_factor)
+        old_y0 = compute_particle_anchor(old_y, extended_grid[1], shape_factor)
+        old_z0 = compute_particle_anchor(old_z, extended_grid[2], shape_factor)
         # compute the nearest grid point to the particle's old position
 
-        deltax = particle_axis_offset(x, x0, grid[0])
-        deltay = particle_axis_offset(y, y0, grid[1])
-        deltaz = particle_axis_offset(z, z0, grid[2])
-        old_deltax = particle_axis_offset(old_x, old_x0, grid[0])
-        old_deltay = particle_axis_offset(old_y, old_y0, grid[1])
-        old_deltaz = particle_axis_offset(old_z, old_z0, grid[2])
+        deltax = particle_axis_offset(x, x0, extended_grid[0])
+        deltay = particle_axis_offset(y, y0, extended_grid[1])
+        deltaz = particle_axis_offset(z, z0, extended_grid[2])
+        old_deltax = particle_axis_offset(old_x, old_x0, extended_grid[0])
+        old_deltay = particle_axis_offset(old_y, old_y0, extended_grid[1])
+        old_deltaz = particle_axis_offset(old_z, old_z0, extended_grid[2])
         # compute the particle's offset from the nearest grid point in each direction at both time steps
 
         shift_x = x0 - old_x0
@@ -117,30 +244,12 @@ def Esirkepov_current(particles, J, constants, world, grid=None, filter=None):
         # compute how many grid points the particles have shifted in each direction.
 
         offsets = jnp.asarray([-2, -1, 0, 1, 2], dtype=x0.dtype)
-        xpts = build_axis_stencil_points(x0, Nx, bc_x, offsets)
-        ypts = build_axis_stencil_points(y0, Ny, bc_y, offsets)
-        zpts = build_axis_stencil_points(z0, Nz, bc_z, offsets)
-        # build the 5-point Esirkepov stencil in each direction.
+        # define the offsets for the 5-point Esirkepov stencil in each direction
 
-        xpts = lax.cond(
-            bc_x == BC_PERIODIC,
-            lambda pts: _remap_staggered_periodic_ghosts(pts, x, Nx, world["x_wind"]),
-            lambda pts: pts,
-            operand=xpts,
-        )
-        ypts = lax.cond(
-            bc_y == BC_PERIODIC,
-            lambda pts: _remap_staggered_periodic_ghosts(pts, y, Ny, world["y_wind"]),
-            lambda pts: pts,
-            operand=ypts,
-        )
-        zpts = lax.cond(
-            bc_z == BC_PERIODIC,
-            lambda pts: _remap_staggered_periodic_ghosts(pts, z, Nz, world["z_wind"]),
-            lambda pts: pts,
-            operand=zpts,
-        )
-        # remap out-of-domain stencil points into the ghost cells across the periodic seam, if needed.
+        xpts = x0[jnp.newaxis, ...] + offsets[:, jnp.newaxis]
+        ypts = y0[jnp.newaxis, ...] + offsets[:, jnp.newaxis]
+        zpts = z0[jnp.newaxis, ...] + offsets[:, jnp.newaxis]
+        # Build the 5-point stencil in the two-ghost deposition buffer.
 
         xw, yw, zw = jax.lax.cond(
             shape_factor == 1,
@@ -167,19 +276,21 @@ def Esirkepov_current(particles, J, constants, world, grid=None, filter=None):
         ozw = [tmp, ozw[0], ozw[1], ozw[2], tmp]
         # pad the weights with zeros so they can be rolled.
 
-        oxw = _roll_old_weights_to_new_frame(oxw, shift_x)
-        oyw = _roll_old_weights_to_new_frame(oyw, shift_y)
-        ozw = _roll_old_weights_to_new_frame(ozw, shift_z)
+        oxw = shift_old_stencil(oxw, shift_x)
+        oyw = shift_old_stencil(oyw, shift_y)
+        ozw = shift_old_stencil(ozw, shift_z)
         # shift the old weights into the new-cell frame so they can be differenced with the current weights.
-        xpts, xw, oxw = _collapse_esirkepov_axis(xpts, xw, oxw, Nx)
-        ypts, yw, oyw = _collapse_esirkepov_axis(ypts, yw, oyw, Ny)
-        zpts, zw, ozw = _collapse_esirkepov_axis(zpts, zw, ozw, Nz)
+        xpts, xw, oxw = collapse_redundant_axis(xpts, xw, oxw, x_active, Nx_ext)
+        ypts, yw, oyw = collapse_redundant_axis(ypts, yw, oyw, y_active, Ny_ext)
+        zpts, zw, ozw = collapse_redundant_axis(zpts, zw, ozw, z_active, Nz_ext)
         # remove dummy stencil points for non 3D simulations
 
         if x_active and y_active and z_active:
+            # if full 3D, calculate full Esirkepov weights with the 3D formula
             Wx_, Wy_, Wz_ = get_3D_esirkepov_weights(xw, yw, zw, oxw, oyw, ozw, N_particles)
         elif (x_active and y_active and (not z_active)) or (x_active and z_active and (not y_active)) or (
             y_active and z_active and (not x_active)
+            # if 2D, calculate Esirkepov weights with the 2D formula for the active plane
         ):
             null_dim = lax.cond(
                 not x_active,
@@ -197,10 +308,13 @@ def Esirkepov_current(particles, J, constants, world, grid=None, filter=None):
                 xw, yw, zw, oxw, oyw, ozw, N_particles, null_dim=null_dim
             )
         elif x_active and (not y_active) and (not z_active):
+            # if 1D in x, calculate Esirkepov weights with the 1D formula for x and pad with zeros for y and z
             Wx_, Wy_, Wz_ = get_1D_esirkepov_weights(xw, yw, zw, oxw, oyw, ozw, N_particles, dim=0)
         elif y_active and (not x_active) and (not z_active):
+            # if 1D in y, calculate Esirkepov weights with the 1D formula for y and pad with zeros for x and z
             Wx_, Wy_, Wz_ = get_1D_esirkepov_weights(xw, yw, zw, oxw, oyw, ozw, N_particles, dim=1)
         elif z_active and (not x_active) and (not y_active):
+            # if 1D in z, calculate Esirkepov weights with the 1D formula for z and pad with zeros for x and y
             Wx_, Wy_, Wz_ = get_1D_esirkepov_weights(xw, yw, zw, oxw, oyw, ozw, N_particles, dim=2)
         # calculate the Esirkepov weights for the active dimensions
 
@@ -241,44 +355,55 @@ def Esirkepov_current(particles, J, constants, world, grid=None, filter=None):
             for i in range(5):
                 for j in range(5):
                     for k in range(5):
-                        Jx = Jx.at[xpts[i, :], ypts[j, :], zpts[k, :]].add(Jx_loc[i, j, k, :], mode="drop")
+                        Jx_ext = Jx_ext.at[xpts[i, :], ypts[j, :], zpts[k, :]].add(Jx_loc[i, j, k, :], mode="drop")
         else:
             for i in range(5):
                 for j in range(5):
                     for k in range(5):
-                        Jx = Jx.at[xpts[i, :], ypts[j, :], zpts[k, :]].add(Fx[i, j, k, :], mode="drop")
+                        Jx_ext = Jx_ext.at[xpts[i, :], ypts[j, :], zpts[k, :]].add(Fx[i, j, k, :], mode="drop")
 
         if y_active:
             for i in range(5):
                 for j in range(5):
                     for k in range(5):
-                        Jy = Jy.at[xpts[i, :], ypts[j, :], zpts[k, :]].add(Jy_loc[i, j, k, :], mode="drop")
+                        Jy_ext = Jy_ext.at[xpts[i, :], ypts[j, :], zpts[k, :]].add(Jy_loc[i, j, k, :], mode="drop")
         else:
             for i in range(5):
                 for j in range(5):
                     for k in range(5):
-                        Jy = Jy.at[xpts[i, :], ypts[j, :], zpts[k, :]].add(Fy[i, j, k, :], mode="drop")
+                        Jy_ext = Jy_ext.at[xpts[i, :], ypts[j, :], zpts[k, :]].add(Fy[i, j, k, :], mode="drop")
 
         if z_active:
             for i in range(5):
                 for j in range(5):
                     for k in range(5):
-                        Jz = Jz.at[xpts[i, :], ypts[j, :], zpts[k, :]].add(Jz_loc[i, j, k, :], mode="drop")
+                        Jz_ext = Jz_ext.at[xpts[i, :], ypts[j, :], zpts[k, :]].add(Jz_loc[i, j, k, :], mode="drop")
         else:
             for i in range(5):
                 for j in range(5):
                     for k in range(5):
-                        Jz = Jz.at[xpts[i, :], ypts[j, :], zpts[k, :]].add(Fz[i, j, k, :], mode="drop")
+                        Jz_ext = Jz_ext.at[xpts[i, :], ypts[j, :], zpts[k, :]].add(Fz[i, j, k, :], mode="drop")
         # deposit the current contributions onto the grid.
 
-    Jx = fold_ghost_cells(Jx, bc_x, bc_y, bc_z)
-    Jy = fold_ghost_cells(Jy, bc_x, bc_y, bc_z)
-    Jz = fold_ghost_cells(Jz, bc_x, bc_y, bc_z)
-    # fold ghost cell deposits back into interior
+        esirkepov_x_bc = species.x_bc
+        esirkepov_y_bc = species.y_bc
+        esirkepov_z_bc = species.z_bc
+        # determine the boundary condition type from the particle species classes
+
+        Jx_ext = ghost_cell_bc_esirkepov(Jx_ext, esirkepov_x_bc, esirkepov_y_bc, esirkepov_z_bc, component_axis=0)
+        Jy_ext = ghost_cell_bc_esirkepov(Jy_ext, esirkepov_x_bc, esirkepov_y_bc, esirkepov_z_bc, component_axis=1)
+        Jz_ext = ghost_cell_bc_esirkepov(Jz_ext, esirkepov_x_bc, esirkepov_y_bc, esirkepov_z_bc, component_axis=2)
+        # Fold the two Esirkepov ghost layers before returning to the solver's
+        # ordinary one-ghost current arrays.
+
+        Jx = Jx + eliminate_esirkepov_ghost_cells(Jx_ext)
+        Jy = Jy + eliminate_esirkepov_ghost_cells(Jy_ext)
+        Jz = Jz + eliminate_esirkepov_ghost_cells(Jz_ext)
+
     Jx = update_ghost_cells(Jx, bc_x, bc_y, bc_z)
     Jy = update_ghost_cells(Jy, bc_x, bc_y, bc_z)
     Jz = update_ghost_cells(Jz, bc_x, bc_y, bc_z)
-    # update ghost cells according to boundary conditions to prepare for field solve
+    # refresh the ordinary one-ghost current halos before the field update
 
     return (Jx, Jy, Jz)
 

--- a/PyPIC3D/deposition/Esirkepov.py
+++ b/PyPIC3D/deposition/Esirkepov.py
@@ -83,6 +83,7 @@ def Esirkepov_current(particles, J, constants, world, grid=None, filter=None):
         q = species.get_charge()
         x, y, z = species.get_forward_position()
         vx, vy, vz = species.get_velocity()
+        active = species.get_active_mask().astype(x.dtype)
         shape_factor = species.get_shape()
         N_particles = species.get_number_of_particles()
         # get particle information
@@ -205,22 +206,22 @@ def Esirkepov_current(particles, J, constants, world, grid=None, filter=None):
 
         dJx = jax.lax.cond(
             x_active,
-            lambda _: -(q / (dy * dz)) / dt * jnp.ones(N_particles),
-            lambda _: q * vx / (dx * dy * dz) * jnp.ones(N_particles),
+            lambda _: active * (-(q / (dy * dz)) / dt) * jnp.ones(N_particles),
+            lambda _: active * q * vx / (dx * dy * dz) * jnp.ones(N_particles),
             operand=None,
         )
 
         dJy = jax.lax.cond(
             y_active,
-            lambda _: -(q / (dx * dz)) / dt * jnp.ones(N_particles),
-            lambda _: q * vy / (dx * dy * dz) * jnp.ones(N_particles),
+            lambda _: active * (-(q / (dx * dz)) / dt) * jnp.ones(N_particles),
+            lambda _: active * q * vy / (dx * dy * dz) * jnp.ones(N_particles),
             operand=None,
         )
 
         dJz = jax.lax.cond(
             z_active,
-            lambda _: -(q / (dx * dy)) / dt * jnp.ones(N_particles),
-            lambda _: q * vz / (dx * dy * dz) * jnp.ones(N_particles),
+            lambda _: active * (-(q / (dx * dy)) / dt) * jnp.ones(N_particles),
+            lambda _: active * q * vz / (dx * dy * dz) * jnp.ones(N_particles),
             operand=None,
         )
         # compute the current contribution prefactors for each active dimension according to Esirkepov's formula

--- a/PyPIC3D/deposition/J_from_rhov.py
+++ b/PyPIC3D/deposition/J_from_rhov.py
@@ -45,6 +45,7 @@ def J_from_rhov(particles, J, constants, world, grid=None, filter="bilinear"):
 
         x, y, z = species.get_forward_position()
         vx, vy, vz = species.get_velocity()
+        active = species.get_active_mask().astype(x.dtype)
         # get the particle velocities and positions at the forward time step (t + dt) for deposition
 
         x = x - vx * world["dt"] / 2
@@ -160,19 +161,19 @@ def J_from_rhov(particles, J, constants, world, grid=None, filter="bilinear"):
             iy = ypts_eff[j, ...]
             iz = zpts_eff[k, ...]
             valx = (
-                (dq * vx)
+                (active * dq * vx)
                 * x_weights_face_eff[i, ...]
                 * y_weights_node_eff[j, ...]
                 * z_weights_node_eff[k, ...]
             )
             valy = (
-                (dq * vy)
+                (active * dq * vy)
                 * x_weights_node_eff[i, ...]
                 * y_weights_face_eff[j, ...]
                 * z_weights_node_eff[k, ...]
             )
             valz = (
-                (dq * vz)
+                (active * dq * vz)
                 * x_weights_node_eff[i, ...]
                 * y_weights_node_eff[j, ...]
                 * z_weights_face_eff[k, ...]

--- a/PyPIC3D/deposition/rho.py
+++ b/PyPIC3D/deposition/rho.py
@@ -31,6 +31,7 @@ def compute_rho(particles, rho, world, constants):
         dq = q / dx / dy / dz
         x, y, z = species.get_forward_position()
         vx, vy, vz = species.get_velocity()
+        active = species.get_active_mask().astype(x.dtype)
         dt = species.dt
         # Deposit from the unwrapped half-step-back position so periodic seam
         # contributions land in the ghost cells instead of being pre-wrapped.
@@ -88,7 +89,7 @@ def compute_rho(particles, rho, world, constants):
             for j in range(ypts.shape[0]):
                 for k in range(zpts.shape[0]):
                     rho = rho.at[xpts[i], ypts[j], zpts[k]].add(
-                        dq * x_weights[i] * y_weights[j] * z_weights[k], mode="drop"
+                        active * dq * x_weights[i] * y_weights[j] * z_weights[k], mode="drop"
                     )
 
     rho = fold_ghost_cells(rho, bc_x, bc_y, bc_z)

--- a/PyPIC3D/diagnostics/fluid_quantities.py
+++ b/PyPIC3D/diagnostics/fluid_quantities.py
@@ -49,6 +49,7 @@ def compute_mass_density(particles, rho, world):
         # calculate the mass per unit volume
         x, y, z = species.get_position()
         # get the position of the particles in the species
+        active = species.get_active_mask().astype(x.dtype)
 
         _, _, deltax, xpts = prepare_particle_axis_stencil(
             x, grid[0], Nx, shape_factor, bc_x, wind=world['x_wind'], ghost_cells=True
@@ -82,7 +83,7 @@ def compute_mass_density(particles, rho, world):
         for i in range(3):
             for j in range(3):
                 for k in range(3):
-                    rho = rho.at[xpts[i], ypts[j], zpts[k]].add( dm * x_weights[i] * y_weights[j] * z_weights[k], mode='drop')
+                    rho = rho.at[xpts[i], ypts[j], zpts[k]].add(active * dm * x_weights[i] * y_weights[j] * z_weights[k], mode='drop')
         # distribute the mass of the particles to the grid points using the weighting factors
 
     rho = fold_ghost_cells(rho, bc_x, bc_y, bc_z)
@@ -130,8 +131,9 @@ def compute_velocity_field(particles, field, direction, world):
         # get the position of the particles in the species
         vx, vy, vz = species.get_velocity()
         # get the velocity of the particles in the species
+        active = species.get_active_mask().astype(x.dtype)
 
-        dv = jnp.array([vx, vy, vz])[direction] / N_particles
+        dv = active * jnp.array([vx, vy, vz])[direction] / N_particles
         # select the velocity component based on the direction
 
         _, _, deltax, xpts = prepare_particle_axis_stencil(
@@ -198,9 +200,10 @@ def compute_pressure_field(particles, field, velocity_field, direction, world):
         # get the position of the particles in the species
         vx, vy, vz = species.get_velocity()
         # get the velocity of the particles in the species
+        active = species.get_active_mask().astype(x.dtype)
 
 
-        v = jnp.array([vx, vy, vz])[direction]
+        v = active * jnp.array([vx, vy, vz])[direction]
         # select the velocity component based on the direction
 
         _, _, deltax, xpts = prepare_particle_axis_stencil(
@@ -236,7 +239,7 @@ def compute_pressure_field(particles, field, velocity_field, direction, world):
                 for k in range(3):
                     vbar = v - velocity_field.at[xpts[i], ypts[j], zpts[k]].get()
 
-                    field = field.at[xpts[i], ypts[j], zpts[k]].add( vbar**2 * x_weights[i] * y_weights[j] * z_weights[k], mode='drop')
+                    field = field.at[xpts[i], ypts[j], zpts[k]].add(active * vbar**2 * x_weights[i] * y_weights[j] * z_weights[k], mode='drop')
         # distribute the pressure moment of the particles to the grid points using the weighting factors
 
     field = fold_ghost_cells(field, bc_x, bc_y, bc_z)

--- a/PyPIC3D/diagnostics/openPMD.py
+++ b/PyPIC3D/diagnostics/openPMD.py
@@ -97,6 +97,15 @@ def _fields_to_interior_map(fields):
     }
     if rest:
         for idx, extra in enumerate(rest, start=1):
+            if extra is None:
+                continue
+            if (
+                isinstance(extra, (list, tuple))
+                and len(extra) == 2
+                and all(isinstance(memory, (list, tuple)) and len(memory) == 3 for memory in extra)
+            ):
+                # PML memory is solver state, not a physical diagnostic field.
+                continue
             if isinstance(extra, (list, tuple)):
                 field_map[f"field_{idx}"] = tuple(comp[interior] for comp in extra)
             else:

--- a/PyPIC3D/diagnostics/openPMD.py
+++ b/PyPIC3D/diagnostics/openPMD.py
@@ -5,8 +5,10 @@ import os
 import numpy as np
 import importlib.metadata
 
-def _ensure_openpmd_array(data, dtype=np.float64):
-    arr = np.squeeze(np.asarray(data, dtype=dtype))
+def _ensure_openpmd_array(data, dtype=np.float64, squeeze=False):
+    arr = np.asarray(data, dtype=dtype)
+    if squeeze:
+        arr = np.squeeze(arr)
     if not arr.flags.c_contiguous or not arr.flags.writeable:
         arr = np.array(arr, dtype=dtype, copy=True, order="C")
     return arr
@@ -124,13 +126,13 @@ def write_openpmd_particles_to_iteration(iteration, particles, constants):
         vx, vy, vz = species.get_velocity()
         gamma = 1 / jnp.sqrt(1.0 - (vx**2 + vy**2 + vz**2) / C**2)
 
-        x = _ensure_openpmd_array(x)
-        y = _ensure_openpmd_array(y)
-        z = _ensure_openpmd_array(z)
-        vx = _ensure_openpmd_array(vx)
-        vy = _ensure_openpmd_array(vy)
-        vz = _ensure_openpmd_array(vz)
-        gamma = _ensure_openpmd_array(gamma)
+        x = _ensure_openpmd_array(x, squeeze=True)
+        y = _ensure_openpmd_array(y, squeeze=True)
+        z = _ensure_openpmd_array(z, squeeze=True)
+        vx = _ensure_openpmd_array(vx, squeeze=True)
+        vy = _ensure_openpmd_array(vy, squeeze=True)
+        vz = _ensure_openpmd_array(vz, squeeze=True)
+        gamma = _ensure_openpmd_array(gamma, squeeze=True)
 
         num_particles = x.shape[0]
         # number of particles in this species
@@ -144,17 +146,17 @@ def write_openpmd_particles_to_iteration(iteration, particles, constants):
         if jnp.ndim(weights) == 0:
             weights = np.full(num_particles, float(weights), dtype=np.float64)
         else:
-            weights = _ensure_openpmd_array(weights)
+            weights = _ensure_openpmd_array(weights, squeeze=True)
 
         if jnp.ndim(particle_mass) == 0:
             masses = np.full(num_particles, float(particle_mass), dtype=np.float64)
         else:
-            masses = _ensure_openpmd_array(particle_mass)
+            masses = _ensure_openpmd_array(particle_mass, squeeze=True)
         
         if jnp.ndim(particle_charge) == 0:
             charges = np.full(num_particles, float(particle_charge), dtype=np.float64)
         else:
-            charges = _ensure_openpmd_array(particle_charge)
+            charges = _ensure_openpmd_array(particle_charge, squeeze=True)
         # ensure weights, masses, and charges are 1D arrays of the correct length for openPMD output
 
         position = species_group["position"]
@@ -214,9 +216,8 @@ def write_openpmd_fields(fields, world, output_dir, plot_t, t, filename="fields"
     field_map = _fields_to_interior_map(fields)
     # extract physical interior (strip ghost cells)
 
-    Nx, Ny, Nz = field_map["rho"].shape
-    active_dims = (Nx > 1, Ny > 1, Nz > 1)
-    # determine active dimensions from interior shape
+    active_dims = (1, 1, 1)
+    # keep singleton mesh axes so thin 2D runs stay in physical x-y-z coordinates
 
 
     series = _open_openpmd_series(output_dir, filename, file_extension=file_extension)
@@ -381,9 +382,8 @@ def write_openpmd_initial_fields(fields, world, output_dir, filename="initial_fi
     field_map = _fields_to_interior_map(fields)
     # extract physical interior (strip ghost cells)
 
-    Nx, Ny, Nz = field_map["rho"].shape
-    active_dims = (Nx > 1, Ny > 1, Nz > 1)
-    # determine active dimensions from interior shape
+    active_dims = (1, 1, 1)
+    # keep singleton mesh axes so thin 2D runs stay in physical x-y-z coordinates
 
 
     output_path = os.path.join(output_dir, "data", "initial_fields")

--- a/PyPIC3D/diagnostics/openPMD.py
+++ b/PyPIC3D/diagnostics/openPMD.py
@@ -104,7 +104,7 @@ def _fields_to_interior_map(fields):
             if (
                 isinstance(extra, (list, tuple))
                 and len(extra) == 2
-                and all(isinstance(memory, (list, tuple)) and len(memory) == 3 for memory in extra)
+                and all(isinstance(memory, (list, tuple)) and len(memory) == 6 for memory in extra)
             ):
                 # PML memory is solver state, not a physical diagnostic field.
                 continue

--- a/PyPIC3D/diagnostics/openPMD.py
+++ b/PyPIC3D/diagnostics/openPMD.py
@@ -83,17 +83,20 @@ def _write_openpmd_vector_mesh(iteration, name, components, world, active_dims=(
 
 def _fields_to_interior_map(fields):
     """Extract physical interior (strip ghost cells) from a fields tuple and return a field_map dict."""
-    E, B, J, rho, *rest = fields
+    E, B, J, rho, phi, external_fields, *rest = fields
     interior = (slice(1, -1), slice(1, -1), slice(1, -1))
+    external_E, external_B = external_fields
     field_map = {
         "E": tuple(comp[interior] for comp in E),
         "B": tuple(comp[interior] for comp in B),
         "J": tuple(comp[interior] for comp in J),
         "rho": rho[interior],
+        "phi": phi[interior],
+        "external_E": tuple(comp[interior] for comp in external_E),
+        "external_B": tuple(comp[interior] for comp in external_B),
     }
     if rest:
-        field_map["phi"] = rest[0][interior]
-        for idx, extra in enumerate(rest[1:], start=1):
+        for idx, extra in enumerate(rest, start=1):
             if isinstance(extra, (list, tuple)):
                 field_map[f"field_{idx}"] = tuple(comp[interior] for comp in extra)
             else:

--- a/PyPIC3D/evolve.py
+++ b/PyPIC3D/evolve.py
@@ -125,7 +125,7 @@ def time_loop_electrodynamic(particles, fields, world, constants, curl_func, J_f
     """
 
 
-    E, B, J, rho, phi, external_fields = fields
+    E, B, J, rho, phi, external_fields, *rest = fields
     # unpack the fields
     center_grid = world['grids']['center']
     vertex_grid = world['grids']['vertex']
@@ -144,16 +144,27 @@ def time_loop_electrodynamic(particles, fields, world, constants, curl_func, J_f
     ################ FIELD UPDATE ################################################################################################
     J = J_func(particles, J, constants, world)
     # calculate the current density based on the selected method
-    E = update_E(E, B, J, world, constants, curl_func)
+    if rest:
+        pml_state = rest[0]
+        E, pml_state = update_E(E, B, J, world, constants, curl_func, pml_state)
+    else:
+        pml_state = None
+        E = update_E(E, B, J, world, constants, curl_func)
     # update the electric field using the curl of the magnetic field
-    B = update_B(E, B, world, constants, curl_func)
+    if pml_state is None:
+        B = update_B(E, B, world, constants, curl_func)
+    else:
+        B, pml_state = update_B(E, B, world, constants, curl_func, pml_state)
     # update the magnetic field using the curl of the electric field
 
     for i in range(len(particles)):
         particles[i].boundary_conditions()
         # apply boundary conditions to the particles
 
-    fields = (E, B, J, rho, phi, external_fields)
+    if pml_state is None:
+        fields = (E, B, J, rho, phi, external_fields)
+    else:
+        fields = (E, B, J, rho, phi, external_fields, pml_state)
     # pack the fields into a tuple
     
 

--- a/PyPIC3D/evolve.py
+++ b/PyPIC3D/evolve.py
@@ -95,7 +95,9 @@ def time_loop_electrodynamic(particles, fields, world, constants, curl_func, J_f
         with `particle_push(...)`, provide an `update_position()` method, and a
         `boundary_conditions()` method.
     fields : tuple
-        Tuple of field arrays/objects in the form `(E, B, J, rho, phi, external_fields)`.
+        Tuple of field arrays/objects in the form
+        `(E, B, J, rho, phi, external_fields, pml_state)`.
+        `pml_state` is `None` when the ordinary Yee update is used.
     world : dict
         Simulation configuration. Must contain `world['dt']` (time step).
     constants : object or dict
@@ -116,8 +118,9 @@ def time_loop_electrodynamic(particles, fields, world, constants, curl_func, J_f
         Updated particle collection after push, position update, and boundary
         conditions.
     fields : tuple
-        Updated fields tuple `(E, B, J, rho, phi, external_fields)` with new E,
-        B, and J. `rho`, `phi`, and `external_fields` are passed through unchanged.
+        Updated fields tuple `(E, B, J, rho, phi, external_fields, pml_state)`
+        with new E, B, and J. `rho`, `phi`, and `external_fields` are passed
+        through unchanged.
     Notes
     -----
     - The update order is: deposit J -> update E -> update B.
@@ -125,7 +128,7 @@ def time_loop_electrodynamic(particles, fields, world, constants, curl_func, J_f
     """
 
 
-    E, B, J, rho, phi, external_fields, *rest = fields
+    E, B, J, rho, phi, external_fields, pml_state = fields
     # unpack the fields
     center_grid = world['grids']['center']
     vertex_grid = world['grids']['vertex']
@@ -144,27 +147,16 @@ def time_loop_electrodynamic(particles, fields, world, constants, curl_func, J_f
     ################ FIELD UPDATE ################################################################################################
     J = J_func(particles, J, constants, world)
     # calculate the current density based on the selected method
-    if rest:
-        pml_state = rest[0]
-        E, pml_state = update_E(E, B, J, world, constants, curl_func, pml_state)
-    else:
-        pml_state = None
-        E = update_E(E, B, J, world, constants, curl_func)
+    E, pml_state = update_E(E, B, J, world, constants, curl_func, pml_state)
     # update the electric field using the curl of the magnetic field
-    if pml_state is None:
-        B = update_B(E, B, world, constants, curl_func)
-    else:
-        B, pml_state = update_B(E, B, world, constants, curl_func, pml_state)
+    B, pml_state = update_B(E, B, world, constants, curl_func, pml_state)
     # update the magnetic field using the curl of the electric field
 
     for i in range(len(particles)):
         particles[i].boundary_conditions()
         # apply boundary conditions to the particles
 
-    if pml_state is None:
-        fields = (E, B, J, rho, phi, external_fields)
-    else:
-        fields = (E, B, J, rho, phi, external_fields, pml_state)
+    fields = (E, B, J, rho, phi, external_fields, pml_state)
     # pack the fields into a tuple
     
 

--- a/PyPIC3D/evolve.py
+++ b/PyPIC3D/evolve.py
@@ -22,6 +22,8 @@ from PyPIC3D.solvers.vector_potential import (
     E_from_A, B_from_A, update_vector_potential
 )
 
+from PyPIC3D.utils import add_external_fields
+
 @partial(jit, static_argnames=("curl_func", "J_func", "solver", "relativistic", "particle_pusher"))
 def time_loop_electrostatic(particles, fields, world, constants, curl_func, J_func, solver, relativistic=True, particle_pusher="boris"):
     """
@@ -35,7 +37,7 @@ def time_loop_electrostatic(particles, fields, world, constants, curl_func, J_fu
 
     Args:
         particles (list): List of particle objects to be advanced.
-        fields (tuple): Tuple containing the field arrays (E, B, J, rho, phi).
+        fields (tuple): Tuple containing the field arrays (E, B, J, rho, phi, external_fields).
         world (dict): Dictionary containing simulation parameters (e.g., time step 'dt').
         constants (dict): Dictionary of physical constants used in the simulation.
         curl_func (callable): Function to compute the curl of a field (not used in this function).
@@ -43,18 +45,20 @@ def time_loop_electrostatic(particles, fields, world, constants, curl_func, J_fu
         solver (callable): Function or object to solve the Poisson equation for the electric field.
 
     Returns:
-        tuple: Updated particles list and fields tuple (E, B, J, rho, phi).
+        tuple: Updated particles list and fields tuple (E, B, J, rho, phi, external_fields).
     """
 
-    E, B, J, rho, phi = fields
+    E, B, J, rho, phi, external_fields = fields
     # unpack the fields
     center_grid = world['grids']['center']
     vertex_grid = world['grids']['vertex']
+    push_E, push_B = add_external_fields(E, B, external_fields)
+    # particles see evolved fields plus external-only fields
 
     ################ PARTICLE PUSH ########################################################################################
     for i in range(len(particles)):
 
-        particles[i] = particle_push(particles[i], E, B, vertex_grid, center_grid, world['dt'], constants, relativistic=relativistic, particle_pusher=particle_pusher)
+        particles[i] = particle_push(particles[i], push_E, push_B, vertex_grid, center_grid, world['dt'], constants, relativistic=relativistic, particle_pusher=particle_pusher)
         # use the selected particle pusher for particle velocities
 
         particles[i].update_position()
@@ -64,7 +68,7 @@ def time_loop_electrostatic(particles, fields, world, constants, curl_func, J_fu
     E, phi, rho = calculate_electrostatic_fields(world, particles, constants, rho, phi, solver, 'periodic')
     # calculate the electric field using the Poisson equation
 
-    fields = (E, B, J, rho, phi)
+    fields = (E, B, J, rho, phi, external_fields)
     # pack the fields into a tuple
 
     for i in range(len(particles)):
@@ -91,7 +95,7 @@ def time_loop_electrodynamic(particles, fields, world, constants, curl_func, J_f
         with `particle_push(...)`, provide an `update_position()` method, and a
         `boundary_conditions()` method.
     fields : tuple
-        Tuple of field arrays/objects in the form `(E, B, J, rho, phi)`.
+        Tuple of field arrays/objects in the form `(E, B, J, rho, phi, external_fields)`.
     world : dict
         Simulation configuration. Must contain `world['dt']` (time step).
     constants : object or dict
@@ -112,8 +116,8 @@ def time_loop_electrodynamic(particles, fields, world, constants, curl_func, J_f
         Updated particle collection after push, position update, and boundary
         conditions.
     fields : tuple
-        Updated fields tuple `(E, B, J, rho, phi)` with new E, B, and J. `rho` and
-        `phi` are passed through unchanged.
+        Updated fields tuple `(E, B, J, rho, phi, external_fields)` with new E,
+        B, and J. `rho`, `phi`, and `external_fields` are passed through unchanged.
     Notes
     -----
     - The update order is: deposit J -> update E -> update B.
@@ -121,15 +125,17 @@ def time_loop_electrodynamic(particles, fields, world, constants, curl_func, J_f
     """
 
 
-    E, B, J, rho, phi = fields
+    E, B, J, rho, phi, external_fields = fields
     # unpack the fields
     center_grid = world['grids']['center']
     vertex_grid = world['grids']['vertex']
+    push_E, push_B = add_external_fields(E, B, external_fields)
+    # particles see evolved fields plus external-only fields
 
     ################ PARTICLE PUSH ########################################################################################
     for i in range(len(particles)):
 
-        particles[i] = particle_push(particles[i], E, B, center_grid, vertex_grid, world['dt'], constants, relativistic=relativistic, particle_pusher=particle_pusher)
+        particles[i] = particle_push(particles[i], push_E, push_B, center_grid, vertex_grid, world['dt'], constants, relativistic=relativistic, particle_pusher=particle_pusher)
         # use the selected particle pusher for particle velocities
 
         particles[i].update_position()
@@ -147,7 +153,7 @@ def time_loop_electrodynamic(particles, fields, world, constants, curl_func, J_f
         particles[i].boundary_conditions()
         # apply boundary conditions to the particles
 
-    fields = (E, B, J, rho, phi)
+    fields = (E, B, J, rho, phi, external_fields)
     # pack the fields into a tuple
     
 
@@ -173,9 +179,9 @@ def time_loop_vector_potential(particles, fields, world, constants, curl_func, J
         with `particle_push(...)`, provide `update_position()`, and
         `boundary_conditions()` methods.
     fields : tuple
-        Field tuple in the order `(E, B, J, rho, phi, A2, A1, A0)`, where `A2`
-        denotes the newest vector potential, `A1` the previous, and `A0` the
-        older one (used for time differencing).
+        Field tuple in the order `(E, B, J, rho, phi, external_fields, A2, A1, A0)`,
+        where `external_fields` is added only for particle pushes, `A2` denotes
+        the newest vector potential, `A1` the previous, and `A0` the older one.
     world : dict
         Simulation parameters. Must at least contain `'dt'` (time step).
     constants : Any
@@ -196,8 +202,8 @@ def time_loop_vector_potential(particles, fields, world, constants, curl_func, J
         Updated particle collection after push, position update, and boundary
         conditions.
     fields : tuple
-        Updated field tuple `(E, B, J, rho, phi, A2, A1, A0)` after advancing A
-        and recomputing E, B, and J.
+        Updated field tuple `(E, B, J, rho, phi, external_fields, A2, A1, A0)`
+        after advancing A and recomputing E, B, and J.
 
     Notes
     -----
@@ -209,15 +215,17 @@ def time_loop_vector_potential(particles, fields, world, constants, curl_func, J
       currently not used inside this function but may be part of a broader API.
     """
 
-    E, B, J, rho, phi, A2, A1, A0 = fields
+    E, B, J, rho, phi, external_fields, A2, A1, A0 = fields
     # unpack the fields
     center_grid = world['grids']['center']
     vertex_grid = world['grids']['vertex']
+    push_E, push_B = add_external_fields(E, B, external_fields)
+    # particles see evolved fields plus external-only fields
 
     ################ PARTICLE PUSH ########################################################################################
     for i in range(len(particles)):
 
-        particles[i] = particle_push(particles[i], E, B, center_grid, vertex_grid, world['dt'], constants, relativistic=relativistic, particle_pusher=particle_pusher)
+        particles[i] = particle_push(particles[i], push_E, push_B, center_grid, vertex_grid, world['dt'], constants, relativistic=relativistic, particle_pusher=particle_pusher)
         # use the selected particle pusher for particle velocities
 
         particles[i].update_position()
@@ -241,7 +249,7 @@ def time_loop_vector_potential(particles, fields, world, constants, curl_func, J
         particles[i].boundary_conditions()
         # apply boundary conditions to the particles
 
-    fields = (E, B, J, rho, phi, A2, A1, A0)
+    fields = (E, B, J, rho, phi, external_fields, A2, A1, A0)
     # pack the fields into a tuple
 
 

--- a/PyPIC3D/initialization.py
+++ b/PyPIC3D/initialization.py
@@ -57,8 +57,8 @@ from PyPIC3D.solvers.vector_potential import initialize_vector_potential
 from PyPIC3D.boundary_conditions.grid_and_stencil import BC_CONDUCTING, BC_PERIODIC
 from PyPIC3D.boundary_conditions.boundaryconditions import update_ghost_cells
 from PyPIC3D.boundary_conditions.PML import (
-    build_pml_metadata,
     initialize_pml_state,
+    load_pml_from_toml,
     update_ghost_cells_for_pml,
 )
 
@@ -272,8 +272,7 @@ def initialize_simulation(toml_file):
     pml_active = bool(raw_pml)
     if pml_active and (solver != "fdtd" or electrostatic):
         raise ValueError("PML is only supported for the fdtd electrodynamic solver")
-    pml_metadata = build_pml_metadata(raw_pml, world, constants)
-    world["pml"] = pml_metadata
+    world["pml"] = load_pml_from_toml(raw_pml, world, constants)
 
     world = convert_to_jax_compatible(world)
     constants = convert_to_jax_compatible(constants)
@@ -433,13 +432,18 @@ def initialize_simulation(toml_file):
         # initialize the vector potential A based on the current density J
         fields = (E, B, J, rho, phi, external_fields, A2, A1, A0)
         # define the fields tuple for the vector potential solver
-    elif pml_active:
-        pml_state = initialize_pml_state(world)
-        fields = (E, B, J, rho, phi, external_fields, pml_state)
-        # define the fields tuple for electrodynamic FDTD with field PML state
-    else:
+    elif electrostatic:
         fields = (E, B, J, rho, phi, external_fields)
-        # define the fields tuple for the electrodynamic and electrostatic solvers
+        # define the fields tuple for the electrostatic solver
+    else:
+        if pml_active:
+            pml_state = initialize_pml_state(world)
+        else:
+            pml_state = None
+        # electrodynamic FDTD always carries the PML state slot; None means
+        # ordinary, unstretched Yee derivatives.
+        fields = (E, B, J, rho, phi, external_fields, pml_state)
+        # define the fields tuple for the electrodynamic FDTD solver
 
     if plotting_parameters['dump_fields']:
         write_openpmd_initial_fields(fields, world, simulation_parameters['output_dir'], filename="initial_fields.h5")

--- a/PyPIC3D/initialization.py
+++ b/PyPIC3D/initialization.py
@@ -112,7 +112,7 @@ def default_parameters():
         "output_dir": os.getcwd(),
         "solver": "fdtd",  # solver: spectral, fdtd, vector_potential, curl_curl
         "fast_backend": "flat",  # flat | default (flat when compatible, else fallback)
-        "particle_bc": "periodic",  # particle boundary conditions: periodic, absorb, reflect
+        "particle_bc": "periodic",  # particle boundary conditions: periodic, absorbing, reflecting
         # "bc": "periodic",  # boundary conditions: periodic, dirichlet, neumann
         "x_bc": "periodic",  # x boundary conditions: periodic, conducting
         "y_bc": "periodic",  # y boundary conditions: periodic, conducting

--- a/PyPIC3D/initialization.py
+++ b/PyPIC3D/initialization.py
@@ -19,7 +19,7 @@ from PyPIC3D.utils import (
     update_parameters_from_toml,
     build_yee_grid, convert_to_jax_compatible, load_external_fields_from_toml,
     print_stats, particle_sanity_check, build_plasma_parameters_dict,
-    make_dir, compute_energy, build_collocated_grid
+    make_dir, compute_energy, build_collocated_grid, add_external_fields
 )
 
 from PyPIC3D.solvers.pstd import (
@@ -331,12 +331,17 @@ def initialize_simulation(toml_file):
 
     E, B, J, phi, rho = initialize_fields(Nx, Ny, Nz)
     # initialize the electric and magnetic fields
+    external_fields = (
+        tuple(jax.numpy.zeros_like(comp) for comp in E),
+        tuple(jax.numpy.zeros_like(comp) for comp in B),
+    )
+    # external_fields stores prescribed E/B that particles see but Maxwell does not evolve
 
     # load any external fields
     fields = [component for field in [E, B, J] for component in field]
     # convert the E, B, and J tuples into one big list
-    fields = load_external_fields_from_toml(fields, toml_file)
-    # add any external fields to the simulation
+    fields, external_fields = load_external_fields_from_toml(fields, external_fields, toml_file)
+    # route configured fields into either evolved fields or external-only fields
     E, B, J = fields[:3], fields[3:6], fields[6:9]
     # convert the fields list back into tuples
 
@@ -348,6 +353,11 @@ def initialize_simulation(toml_file):
     E = tuple(update_ghost_cells(comp, bc_x, bc_y, bc_z) for comp in E)
     B = tuple(update_ghost_cells(comp, bc_x, bc_y, bc_z) for comp in B)
     # fill ghost cells for the initial E and B fields
+    external_E, external_B = external_fields
+    external_E = tuple(update_ghost_cells(comp, bc_x, bc_y, bc_z) for comp in external_E)
+    external_B = tuple(update_ghost_cells(comp, bc_x, bc_y, bc_z) for comp in external_B)
+    external_fields = (external_E, external_B)
+    # fill ghost cells for external fields before they are interpolated to particles
 
     if solver == "spectral":
         curl_func = functools.partial(spectral_curl, world=world)
@@ -356,7 +366,9 @@ def initialize_simulation(toml_file):
 
 
     ######################### COMPUTE INITIAL ENERGY ########################################################
-    e_energy, b_energy, kinetic_energy = compute_energy(particles, E, B, world, constants)
+    total_E, total_B = add_external_fields(E, B, external_fields)
+    # energy diagnostics use the same total fields that the particle pusher sees
+    e_energy, b_energy, kinetic_energy = compute_energy(particles, total_E, total_B, world, constants)
     # compute the initial energy of the system
     print(f"Initial Electric Field Energy: {e_energy:.2e} J")
     print(f"Initial Magnetic Field Energy: {b_energy:.2e} J")
@@ -397,10 +409,10 @@ def initialize_simulation(toml_file):
     if solver == "vector_potential":
         A2, A1, A0 = initialize_vector_potential(J, world, constants)
         # initialize the vector potential A based on the current density J
-        fields = (E, B, J, rho, phi, A2, A1, A0)
+        fields = (E, B, J, rho, phi, external_fields, A2, A1, A0)
         # define the fields tuple for the vector potential solver
     else:
-        fields = (E, B, J, rho, phi)
+        fields = (E, B, J, rho, phi, external_fields)
         # define the fields tuple for the electrodynamic and electrostatic solvers
 
     if plotting_parameters['dump_fields']:

--- a/PyPIC3D/initialization.py
+++ b/PyPIC3D/initialization.py
@@ -56,6 +56,11 @@ from PyPIC3D.solvers.vector_potential import initialize_vector_potential
 
 from PyPIC3D.boundary_conditions.grid_and_stencil import BC_CONDUCTING, BC_PERIODIC
 from PyPIC3D.boundary_conditions.boundaryconditions import update_ghost_cells
+from PyPIC3D.boundary_conditions.PML import (
+    build_pml_metadata,
+    initialize_pml_state,
+    update_ghost_cells_for_pml,
+)
 
 
 def _encode_field_bc(bc_name):
@@ -261,6 +266,15 @@ def initialize_simulation(toml_file):
     }
     # set the simulation world parameters
 
+    raw_pml = []
+    if toml_file is not None:
+        raw_pml = toml_file.get("pml", [])
+    pml_active = bool(raw_pml)
+    if pml_active and (solver != "fdtd" or electrostatic):
+        raise ValueError("PML is only supported for the fdtd electrodynamic solver")
+    pml_metadata = build_pml_metadata(raw_pml, world, constants)
+    world["pml"] = pml_metadata
+
     world = convert_to_jax_compatible(world)
     constants = convert_to_jax_compatible(constants)
     simulation_parameters = convert_to_jax_compatible(simulation_parameters)
@@ -350,12 +364,20 @@ def initialize_simulation(toml_file):
     bc_z = world['boundary_conditions']['z']
     # get the boundary condition codes
 
-    E = tuple(update_ghost_cells(comp, bc_x, bc_y, bc_z) for comp in E)
-    B = tuple(update_ghost_cells(comp, bc_x, bc_y, bc_z) for comp in B)
+    if pml_active:
+        E = tuple(update_ghost_cells_for_pml(comp, world) for comp in E)
+        B = tuple(update_ghost_cells_for_pml(comp, world) for comp in B)
+    else:
+        E = tuple(update_ghost_cells(comp, bc_x, bc_y, bc_z) for comp in E)
+        B = tuple(update_ghost_cells(comp, bc_x, bc_y, bc_z) for comp in B)
     # fill ghost cells for the initial E and B fields
     external_E, external_B = external_fields
-    external_E = tuple(update_ghost_cells(comp, bc_x, bc_y, bc_z) for comp in external_E)
-    external_B = tuple(update_ghost_cells(comp, bc_x, bc_y, bc_z) for comp in external_B)
+    if pml_active:
+        external_E = tuple(update_ghost_cells_for_pml(comp, world) for comp in external_E)
+        external_B = tuple(update_ghost_cells_for_pml(comp, world) for comp in external_B)
+    else:
+        external_E = tuple(update_ghost_cells(comp, bc_x, bc_y, bc_z) for comp in external_E)
+        external_B = tuple(update_ghost_cells(comp, bc_x, bc_y, bc_z) for comp in external_B)
     external_fields = (external_E, external_B)
     # fill ghost cells for external fields before they are interpolated to particles
 
@@ -411,6 +433,10 @@ def initialize_simulation(toml_file):
         # initialize the vector potential A based on the current density J
         fields = (E, B, J, rho, phi, external_fields, A2, A1, A0)
         # define the fields tuple for the vector potential solver
+    elif pml_active:
+        pml_state = initialize_pml_state(world)
+        fields = (E, B, J, rho, phi, external_fields, pml_state)
+        # define the fields tuple for electrodynamic FDTD with field PML state
     else:
         fields = (E, B, J, rho, phi, external_fields)
         # define the fields tuple for the electrodynamic and electrostatic solvers

--- a/PyPIC3D/particles/flat_particles.py
+++ b/PyPIC3D/particles/flat_particles.py
@@ -38,6 +38,7 @@ class flat_particle_species:
         shape,
         dt,
         species_meta,
+        active_mask=None,
     ):
         self.name = name
         self.N_particles = N_particles
@@ -71,6 +72,9 @@ class flat_particle_species:
         self.shape = shape
         self.dt = dt
         self.species_meta = species_meta
+        if active_mask is None:
+            active_mask = jnp.ones_like(x1, dtype=bool)
+        self.active_mask = active_mask
 
     def get_name(self):
         return self.name
@@ -87,8 +91,15 @@ class flat_particle_species:
     def get_velocity(self):
         return self.v1, self.v2, self.v3
 
+    def get_active_velocity(self):
+        active = self.active_mask.astype(self.v1.dtype)
+        return active * self.v1, active * self.v2, active * self.v3
+
     def get_forward_position(self):
         return self.x1, self.x2, self.x3
+
+    def get_active_mask(self):
+        return self.active_mask
 
     def get_position(self):
         x1_back = self.x1 - self.v1 * self.dt / 2
@@ -128,25 +139,27 @@ class flat_particle_species:
 
     def momentum(self):
         vmag = jnp.sqrt(self.v1**2 + self.v2**2 + self.v3**2)
-        return jnp.sum(vmag * self.mass * self.weight)
+        return jnp.sum(self.active_mask.astype(vmag.dtype) * vmag * self.mass * self.weight)
 
     def set_velocity(self, v1, v2, v3):
         if self.update_v:
+            active = self.active_mask
             if self.update_vx:
-                self.v1 = v1
+                self.v1 = jnp.where(active, v1, self.v1)
             if self.update_vy:
-                self.v2 = v2
+                self.v2 = jnp.where(active, v2, self.v2)
             if self.update_vz:
-                self.v3 = v3
+                self.v3 = jnp.where(active, v3, self.v3)
 
     def update_position(self):
         if self.update_pos:
+            active = self.active_mask.astype(self.x1.dtype)
             if self.update_x:
-                self.x1 = self.x1 + self.v1 * self.dt
+                self.x1 = self.x1 + active * self.v1 * self.dt
             if self.update_y:
-                self.x2 = self.x2 + self.v2 * self.dt
+                self.x2 = self.x2 + active * self.v2 * self.dt
             if self.update_z:
-                self.x3 = self.x3 + self.v3 * self.dt
+                self.x3 = self.x3 + active * self.v3 * self.dt
 
     def boundary_conditions(self):
         half_x = self.x_wind / 2
@@ -170,7 +183,7 @@ class flat_particle_species:
         )
 
     def tree_flatten(self):
-        children = (self.x1, self.x2, self.x3, self.v1, self.v2, self.v3)
+        children = (self.x1, self.x2, self.x3, self.v1, self.v2, self.v3, self.active_mask)
         aux_data = (
             self.name,
             self.N_particles,
@@ -203,7 +216,7 @@ class flat_particle_species:
 
     @classmethod
     def tree_unflatten(cls, aux_data, children):
-        x1, x2, x3, v1, v2, v3 = children
+        x1, x2, x3, v1, v2, v3, active_mask = children
         (
             name,
             N_particles,
@@ -265,6 +278,7 @@ class flat_particle_species:
             shape=shape,
             dt=dt,
             species_meta=species_meta,
+            active_mask=active_mask,
         )
 
 
@@ -298,17 +312,20 @@ def to_flat_particles(particles):
     species_meta = []
     x_list, y_list, z_list = [], [], []
     vx_list, vy_list, vz_list = [], [], []
+    active_list = []
     q_list, m_list, w_list, T_list = [], [], [], []
 
     for species in particles:
         x, y, z = species.get_forward_position()
         vx, vy, vz = species.get_velocity()
+        active = species.get_active_mask()
         x_list.append(x)
         y_list.append(y)
         z_list.append(z)
         vx_list.append(vx)
         vy_list.append(vy)
         vz_list.append(vz)
+        active_list.append(active)
         q_list.append(jnp.full_like(x, species.charge))
         m_list.append(jnp.full_like(x, species.mass))
         w_list.append(jnp.full_like(x, species.weight))
@@ -334,6 +351,7 @@ def to_flat_particles(particles):
     vx = jnp.concatenate(vx_list, axis=0)
     vy = jnp.concatenate(vy_list, axis=0)
     vz = jnp.concatenate(vz_list, axis=0)
+    active_mask = jnp.concatenate(active_list, axis=0)
     charge = jnp.concatenate(q_list, axis=0)
     mass = jnp.concatenate(m_list, axis=0)
     weight = jnp.concatenate(w_list, axis=0)
@@ -373,5 +391,6 @@ def to_flat_particles(particles):
         shape=first.shape,
         dt=first.dt,
         species_meta=species_meta,
+        active_mask=active_mask,
     )
     return [flat]

--- a/PyPIC3D/particles/particle_initialization.py
+++ b/PyPIC3D/particles/particle_initialization.py
@@ -201,21 +201,21 @@ def load_particles_from_toml(config, simulation_parameters, world, constants):
 
         x_bc = "periodic"
         if "x_bc" in config[toml_key]:
-            assert config[toml_key]["x_bc"] in ["periodic", "reflecting"], (
+            assert config[toml_key]["x_bc"] in ["periodic", "reflecting", "absorbing"], (
                 f"Invalid x boundary condition: {config[toml_key]['x_bc']}"
             )
             x_bc = config[toml_key]["x_bc"]
 
         y_bc = "periodic"
         if "y_bc" in config[toml_key]:
-            assert config[toml_key]["y_bc"] in ["periodic", "reflecting"], (
+            assert config[toml_key]["y_bc"] in ["periodic", "reflecting", "absorbing"], (
                 f"Invalid y boundary condition: {config[toml_key]['y_bc']}"
             )
             y_bc = config[toml_key]["y_bc"]
 
         z_bc = "periodic"
         if "z_bc" in config[toml_key]:
-            assert config[toml_key]["z_bc"] in ["periodic", "reflecting"], (
+            assert config[toml_key]["z_bc"] in ["periodic", "reflecting", "absorbing"], (
                 f"Invalid z boundary condition: {config[toml_key]['z_bc']}"
             )
             z_bc = config[toml_key]["z_bc"]

--- a/PyPIC3D/particles/species_class.py
+++ b/PyPIC3D/particles/species_class.py
@@ -74,6 +74,7 @@ class particle_species:
         update_v=True,
         shape=1,
         dt=0,
+        active_mask=None,
     ):
         self.name = name
         self.N_particles = N_particles
@@ -102,6 +103,9 @@ class particle_species:
         self.y_reflecting = y_bc == "reflecting"
         self.z_periodic = z_bc == "periodic"
         self.z_reflecting = z_bc == "reflecting"
+        self.x_absorbing = x_bc == "absorbing"
+        self.y_absorbing = y_bc == "absorbing"
+        self.z_absorbing = z_bc == "absorbing"
         self.update_x = update_x
         self.update_y = update_y
         self.update_z = update_z
@@ -116,6 +120,9 @@ class particle_species:
         self.x1 = x1
         self.x2 = x2
         self.x3 = x3
+        if active_mask is None:
+            active_mask = jnp.ones_like(x1, dtype=bool)
+        self.active_mask = active_mask
 
     def get_name(self):
         return self.name
@@ -132,8 +139,15 @@ class particle_species:
     def get_velocity(self):
         return self.v1, self.v2, self.v3
 
+    def get_active_velocity(self):
+        active = self.active_mask.astype(self.v1.dtype)
+        return active * self.v1, active * self.v2, active * self.v3
+
     def get_forward_position(self):
         return self.x1, self.x2, self.x3
+
+    def get_active_mask(self):
+        return self.active_mask
 
     def get_position(self):
         x1_back = self.x1 - self.v1 * self.dt / 2
@@ -184,12 +198,13 @@ class particle_species:
 
     def set_velocity(self, v1, v2, v3):
         if self.update_v:
+            active = self.active_mask
             if self.update_vx:
-                self.v1 = v1
+                self.v1 = jnp.where(active, v1, self.v1)
             if self.update_vy:
-                self.v2 = v2
+                self.v2 = jnp.where(active, v2, self.v2)
             if self.update_vz:
-                self.v3 = v3
+                self.v3 = jnp.where(active, v3, self.v3)
 
     def set_position(self, x1, x2, x3):
         self.x1 = x1
@@ -204,10 +219,11 @@ class particle_species:
 
     def kinetic_energy(self):
         v2 = jnp.square(self.v1) + jnp.square(self.v2) + jnp.square(self.v3)
-        return 0.5 * self.weight * self.mass * jnp.sum(v2)
+        return 0.5 * self.weight * self.mass * jnp.sum(self.active_mask.astype(v2.dtype) * v2)
 
     def momentum(self):
-        return self.mass * self.weight * jnp.sum(jnp.sqrt(self.v1**2 + self.v2**2 + self.v3**2))
+        vmag = jnp.sqrt(self.v1**2 + self.v2**2 + self.v3**2)
+        return self.mass * self.weight * jnp.sum(self.active_mask.astype(vmag.dtype) * vmag)
 
     def boundary_conditions(self):
         x1, x2, x3 = self.x1, self.x2, self.x3
@@ -223,20 +239,30 @@ class particle_species:
             x3, v3, self.z_wind, self.half_z_wind, self.z_periodic, self.z_reflecting
         )
 
+        active_mask = self.active_mask
+        if self.x_absorbing:
+            active_mask = active_mask & (x1 <= self.half_x_wind) & (x1 >= -self.half_x_wind)
+        if self.y_absorbing:
+            active_mask = active_mask & (x2 <= self.half_y_wind) & (x2 >= -self.half_y_wind)
+        if self.z_absorbing:
+            active_mask = active_mask & (x3 <= self.half_z_wind) & (x3 >= -self.half_z_wind)
+
         self.x1, self.x2, self.x3 = x1, x2, x3
         self.v1, self.v2, self.v3 = v1, v2, v3
+        self.active_mask = active_mask
 
     def update_position(self):
         if self.update_pos:
+            active = self.active_mask.astype(self.x1.dtype)
             if self.update_x:
-                self.x1 = self.x1 + self.v1 * self.dt
+                self.x1 = self.x1 + active * self.v1 * self.dt
             if self.update_y:
-                self.x2 = self.x2 + self.v2 * self.dt
+                self.x2 = self.x2 + active * self.v2 * self.dt
             if self.update_z:
-                self.x3 = self.x3 + self.v3 * self.dt
+                self.x3 = self.x3 + active * self.v3 * self.dt
 
     def tree_flatten(self):
-        children = (self.v1, self.v2, self.v3, self.x1, self.x2, self.x3)
+        children = (self.v1, self.v2, self.v3, self.x1, self.x2, self.x3, self.active_mask)
 
         aux_data = (
             self.name,
@@ -269,7 +295,7 @@ class particle_species:
 
     @classmethod
     def tree_unflatten(cls, aux_data, children):
-        v1, v2, v3, x1, x2, x3 = children
+        v1, v2, v3, x1, x2, x3, active_mask = children
 
         (
             name,
@@ -331,6 +357,7 @@ class particle_species:
             update_v=update_v,
             shape=shape,
             dt=dt,
+            active_mask=active_mask,
         )
 
         return obj

--- a/PyPIC3D/solvers/electrostatic_yee.py
+++ b/PyPIC3D/solvers/electrostatic_yee.py
@@ -109,7 +109,7 @@ def solve_poisson_with_conjugate_gradient(rho, phi, constants, world, tol=1e-6, 
     def body_fun(state):
         phi, r, p, k = state
 
-        lapl_p = lapl(p)
+        lapl_p = -lapl(p)
         alpha = jnp.sum(r * r) / jnp.sum(p[1:-1, 1:-1, 1:-1] * lapl_p)
         # compute the optimal step size in the direction of the residual
         phi_next = phi.at[1:-1, 1:-1, 1:-1].add(alpha * p[1:-1, 1:-1, 1:-1])

--- a/PyPIC3D/solvers/electrostatic_yee.py
+++ b/PyPIC3D/solvers/electrostatic_yee.py
@@ -110,14 +110,14 @@ def solve_poisson_with_conjugate_gradient(rho, phi, constants, world, tol=1e-6, 
         phi, r, p, k = state
 
         lapl_p = lapl(p)
-        alpha = -1*jnp.sum(r * r) / jnp.sum(p[1:-1, 1:-1, 1:-1] * lapl_p)
+        alpha = jnp.sum(r * r) / jnp.sum(p[1:-1, 1:-1, 1:-1] * lapl_p)
         # compute the optimal step size in the direction of the residual
         phi_next = phi.at[1:-1, 1:-1, 1:-1].add(alpha * p[1:-1, 1:-1, 1:-1])
         # update the potential guess
         phi_next = apply_bc(phi_next)
         # apply boundary conditions to the new potential guess
 
-        r_next = r + alpha * lapl_p
+        r_next = r - alpha * lapl_p
         # compute the new residual after stepping in the direction of p
         beta = jnp.sum(r_next * r_next) / jnp.sum(r * r)
         # compute the optimal scaling for the new search direction

--- a/PyPIC3D/solvers/first_order_yee.py
+++ b/PyPIC3D/solvers/first_order_yee.py
@@ -30,7 +30,9 @@ def update_E(E, B, J, world, constants, curl_func, pml_state=None):
         curl_func (function): A function to calculate the curl of the magnetic field.
 
     Returns:
-        tuple: Updated electric field components (Ex, Ey, Ez).
+        tuple: ``((Ex, Ey, Ez), pml_state)``.  When no PML is active,
+        ``pml_state`` is passed through as ``None`` and the update is the
+        ordinary unstretched Yee update.
     """
 
     Ex, Ey, Ez = E
@@ -65,19 +67,14 @@ def update_E(E, B, J, world, constants, curl_func, pml_state=None):
         curl_y = dBx_dz - dBz_dx
         curl_z = dBy_dx - dBx_dy
     else:
+        # In the PML layer, each Yee derivative is interpreted as a
+        # coordinate-stretched derivative before the curl is assembled.
         (curl_x, curl_y, curl_z), pml_state = apply_pml_to_e_curl(
-            {
-                "dBz_dy": dBz_dy,
-                "dBy_dz": dBy_dz,
-                "dBx_dz": dBx_dz,
-                "dBz_dx": dBz_dx,
-                "dBy_dx": dBy_dx,
-                "dBx_dy": dBx_dy,
-            },
+            (dBz_dy, dBy_dz, dBx_dz, dBz_dx, dBy_dx, dBx_dy),
             world,
             pml_state,
         )
-    # calculate the curl of the magnetic field
+    # calculate the curl of the magnetic field, optionally using stretched derivatives
 
     Ex = Ex.at[1:-1, 1:-1, 1:-1].set(
         Ex[1:-1, 1:-1, 1:-1] + (C**2 * curl_x - Jx[1:-1, 1:-1, 1:-1] / eps) * dt
@@ -119,8 +116,6 @@ def update_E(E, B, J, world, constants, curl_func, pml_state=None):
         Ez = update_ghost_cells_for_pml(Ez, world)
     # fill ghost cells with the updated values
 
-    if pml_state is None:
-        return (Ex, Ey, Ez)
     return (Ex, Ey, Ez), pml_state
 
 
@@ -140,7 +135,9 @@ def update_B(E, B, world, constants, curl_func, pml_state=None):
         curl_func (function): Function to calculate the curl of the electric field.
 
     Returns:
-        tuple: Updated magnetic field components (Bx, By, Bz).
+        tuple: ``((Bx, By, Bz), pml_state)``.  When no PML is active,
+        ``pml_state`` is passed through as ``None`` and the update is the
+        ordinary unstretched Yee update.
     """
 
     dt = world['dt']
@@ -170,19 +167,14 @@ def update_B(E, B, world, constants, curl_func, pml_state=None):
         curl_y = dEx_dz - dEz_dx
         curl_z = dEy_dx - dEx_dy
     else:
+        # In the PML layer, the frequency-space coordinate stretch is carried by
+        # ADE memory terms attached to each finite-difference derivative.
         (curl_x, curl_y, curl_z), pml_state = apply_pml_to_b_curl(
-            {
-                "dEz_dy": dEz_dy,
-                "dEy_dz": dEy_dz,
-                "dEx_dz": dEx_dz,
-                "dEz_dx": dEz_dx,
-                "dEy_dx": dEy_dx,
-                "dEx_dy": dEx_dy,
-            },
+            (dEz_dy, dEy_dz, dEx_dz, dEz_dx, dEy_dx, dEx_dy),
             world,
             pml_state,
         )
-    # calculate the curl of the electric field
+    # calculate the curl of the electric field, optionally using stretched derivatives
 
     Bx = Bx.at[1:-1, 1:-1, 1:-1].set(Bx[1:-1, 1:-1, 1:-1] - dt * curl_x)
     By = By.at[1:-1, 1:-1, 1:-1].set(By[1:-1, 1:-1, 1:-1] - dt * curl_y)
@@ -215,6 +207,4 @@ def update_B(E, B, world, constants, curl_func, pml_state=None):
         Bz = update_ghost_cells_for_pml(Bz, world)
     # fill ghost cells with the updated values
 
-    if pml_state is None:
-        return (Bx, By, Bz)
     return (Bx, By, Bz), pml_state

--- a/PyPIC3D/solvers/first_order_yee.py
+++ b/PyPIC3D/solvers/first_order_yee.py
@@ -5,11 +5,16 @@ from functools import partial
 
 from PyPIC3D.utils import digital_filter
 from PyPIC3D.boundary_conditions.boundaryconditions import update_ghost_cells, apply_conducting_bc
+from PyPIC3D.boundary_conditions.PML import (
+    apply_pml_to_b_curl,
+    apply_pml_to_e_curl,
+    update_ghost_cells_for_pml,
+)
 # import internal libraries
 
 
 @partial(jit, static_argnames=("curl_func",))
-def update_E(E, B, J, world, constants, curl_func):
+def update_E(E, B, J, world, constants, curl_func, pml_state=None):
     """
     Update the electric field components (Ex, Ey, Ez) based on the given parameters.
 
@@ -55,9 +60,23 @@ def update_E(E, B, J, world, constants, curl_func):
     dBy_dx = (By[2:, 1:-1, 1:-1] - By[1:-1, 1:-1, 1:-1]) / dx
     # compute the forward finite differences of the magnetic field
 
-    curl_x = dBz_dy - dBy_dz
-    curl_y = dBx_dz - dBz_dx
-    curl_z = dBy_dx - dBx_dy
+    if pml_state is None:
+        curl_x = dBz_dy - dBy_dz
+        curl_y = dBx_dz - dBz_dx
+        curl_z = dBy_dx - dBx_dy
+    else:
+        (curl_x, curl_y, curl_z), pml_state = apply_pml_to_e_curl(
+            {
+                "dBz_dy": dBz_dy,
+                "dBy_dz": dBy_dz,
+                "dBx_dz": dBx_dz,
+                "dBz_dx": dBz_dx,
+                "dBy_dx": dBy_dx,
+                "dBx_dy": dBx_dy,
+            },
+            world,
+            pml_state,
+        )
     # calculate the curl of the magnetic field
 
     Ex = Ex.at[1:-1, 1:-1, 1:-1].set(
@@ -71,9 +90,14 @@ def update_E(E, B, J, world, constants, curl_func):
     )
     # update the electric field from Maxwell's equations
 
-    Ex = update_ghost_cells(Ex, bc_x, bc_y, bc_z)
-    Ey = update_ghost_cells(Ey, bc_x, bc_y, bc_z)
-    Ez = update_ghost_cells(Ez, bc_x, bc_y, bc_z)
+    if pml_state is None:
+        Ex = update_ghost_cells(Ex, bc_x, bc_y, bc_z)
+        Ey = update_ghost_cells(Ey, bc_x, bc_y, bc_z)
+        Ez = update_ghost_cells(Ez, bc_x, bc_y, bc_z)
+    else:
+        Ex = update_ghost_cells_for_pml(Ex, world)
+        Ey = update_ghost_cells_for_pml(Ey, world)
+        Ez = update_ghost_cells_for_pml(Ez, world)
     # refresh ghost cells before any stencil-based post-processing
 
     alpha = constants['alpha']
@@ -85,16 +109,23 @@ def update_E(E, B, J, world, constants, curl_func):
     Ex, Ey, Ez = apply_conducting_bc((Ex, Ey, Ez), bc_x, bc_y, bc_z)
     # enforce conducting boundary conditions on tangential E
 
-    Ex = update_ghost_cells(Ex, bc_x, bc_y, bc_z)
-    Ey = update_ghost_cells(Ey, bc_x, bc_y, bc_z)
-    Ez = update_ghost_cells(Ez, bc_x, bc_y, bc_z)
+    if pml_state is None:
+        Ex = update_ghost_cells(Ex, bc_x, bc_y, bc_z)
+        Ey = update_ghost_cells(Ey, bc_x, bc_y, bc_z)
+        Ez = update_ghost_cells(Ez, bc_x, bc_y, bc_z)
+    else:
+        Ex = update_ghost_cells_for_pml(Ex, world)
+        Ey = update_ghost_cells_for_pml(Ey, world)
+        Ez = update_ghost_cells_for_pml(Ez, world)
     # fill ghost cells with the updated values
 
-    return (Ex, Ey, Ez)
+    if pml_state is None:
+        return (Ex, Ey, Ez)
+    return (Ex, Ey, Ez), pml_state
 
 
 @partial(jit, static_argnames=("curl_func",))
-def update_B(E, B, world, constants, curl_func):
+def update_B(E, B, world, constants, curl_func, pml_state=None):
     """
     Update the magnetic field components (Bx, By, Bz) using the curl of the electric field.
 
@@ -134,9 +165,23 @@ def update_B(E, B, world, constants, curl_func):
     dEy_dx = (Ey[1:-1, 1:-1, 1:-1] - Ey[:-2, 1:-1, 1:-1]) / dx
     # compute the backward finite differences of the electric field
 
-    curl_x = dEz_dy - dEy_dz
-    curl_y = dEx_dz - dEz_dx
-    curl_z = dEy_dx - dEx_dy
+    if pml_state is None:
+        curl_x = dEz_dy - dEy_dz
+        curl_y = dEx_dz - dEz_dx
+        curl_z = dEy_dx - dEx_dy
+    else:
+        (curl_x, curl_y, curl_z), pml_state = apply_pml_to_b_curl(
+            {
+                "dEz_dy": dEz_dy,
+                "dEy_dz": dEy_dz,
+                "dEx_dz": dEx_dz,
+                "dEz_dx": dEz_dx,
+                "dEy_dx": dEy_dx,
+                "dEx_dy": dEx_dy,
+            },
+            world,
+            pml_state,
+        )
     # calculate the curl of the electric field
 
     Bx = Bx.at[1:-1, 1:-1, 1:-1].set(Bx[1:-1, 1:-1, 1:-1] - dt * curl_x)
@@ -144,9 +189,14 @@ def update_B(E, B, world, constants, curl_func):
     Bz = Bz.at[1:-1, 1:-1, 1:-1].set(Bz[1:-1, 1:-1, 1:-1] - dt * curl_z)
     # update the magnetic field from Maxwell's equations
 
-    Bx = update_ghost_cells(Bx, bc_x, bc_y, bc_z)
-    By = update_ghost_cells(By, bc_x, bc_y, bc_z)
-    Bz = update_ghost_cells(Bz, bc_x, bc_y, bc_z)
+    if pml_state is None:
+        Bx = update_ghost_cells(Bx, bc_x, bc_y, bc_z)
+        By = update_ghost_cells(By, bc_x, bc_y, bc_z)
+        Bz = update_ghost_cells(Bz, bc_x, bc_y, bc_z)
+    else:
+        Bx = update_ghost_cells_for_pml(Bx, world)
+        By = update_ghost_cells_for_pml(By, world)
+        Bz = update_ghost_cells_for_pml(Bz, world)
     # refresh ghost cells before any stencil-based post-processing
 
     alpha = constants['alpha']
@@ -155,9 +205,16 @@ def update_B(E, B, world, constants, curl_func):
     Bz = digital_filter(Bz, alpha)
     # apply a digital filter to the magnetic field components
 
-    Bx = update_ghost_cells(Bx, bc_x, bc_y, bc_z)
-    By = update_ghost_cells(By, bc_x, bc_y, bc_z)
-    Bz = update_ghost_cells(Bz, bc_x, bc_y, bc_z)
+    if pml_state is None:
+        Bx = update_ghost_cells(Bx, bc_x, bc_y, bc_z)
+        By = update_ghost_cells(By, bc_x, bc_y, bc_z)
+        Bz = update_ghost_cells(Bz, bc_x, bc_y, bc_z)
+    else:
+        Bx = update_ghost_cells_for_pml(Bx, world)
+        By = update_ghost_cells_for_pml(By, world)
+        Bz = update_ghost_cells_for_pml(Bz, world)
     # fill ghost cells with the updated values
 
-    return (Bx, By, Bz)
+    if pml_state is None:
+        return (Bx, By, Bz)
+    return (Bx, By, Bz), pml_state

--- a/PyPIC3D/utils.py
+++ b/PyPIC3D/utils.py
@@ -228,10 +228,11 @@ def compute_energy(particles, E, B, world, constants):
         mass = species.get_mass()
         vx, vy, vz = species.get_velocity()
         v2 = vx**2 + vy**2 + vz**2
+        active = species.get_active_mask().astype(v2.dtype)
         gamma = 1.0 / jnp.sqrt(1 - v2 / C**2)
         momentum2 = jnp.square(mass * gamma ) * v2
         # compute the squared momentum for each particle
-        KE = jnp.sum( jnp.sqrt( momentum2 * C**2 + mass**2 * C**4) - mass * C**2 )
+        KE = jnp.sum(active * (jnp.sqrt(momentum2 * C**2 + mass**2 * C**4) - mass * C**2))
         # compute the kinetic energy for this species
         kinetic_energy += KE
         # add to total kinetic energy

--- a/PyPIC3D/utils.py
+++ b/PyPIC3D/utils.py
@@ -240,6 +240,20 @@ def compute_energy(particles, E, B, world, constants):
     # Kinetic energy of particles
     return e_energy, b_energy, kinetic_energy
 
+
+def add_external_fields(E, B, external_fields):
+    """
+    Add prescribed external fields to the self-consistent fields.
+
+    Maxwell updates should use E and B by themselves. Particle pushes and total
+    energy diagnostics should use the returned totals, because those are the
+    fields particles actually see.
+    """
+    external_E, external_B = external_fields
+    total_E = tuple(e + ext_e for e, ext_e in zip(E, external_E))
+    total_B = tuple(b + ext_b for b, ext_b in zip(B, external_B))
+    return total_E, total_B
+
 def make_dir(path):
     """
     Create a directory if it does not exist.
@@ -629,38 +643,61 @@ def grab_field_keys(config):
             field_keys.append(key)
     return field_keys
 
-def load_external_fields_from_toml(fields, config):
+def load_external_fields_from_toml(fields, external_fields, config):
     """
     Load external fields from a TOML file.
 
     Args:
-        fields (dict): Dictionary containing the external fields.
+        fields (list): Flattened list of evolved E, B, and J field components.
+        external_fields (tuple): External-only E and B field tuples.
         config (dict): Dictionary containing the configuration values.
 
     Returns:
-        dict: Dictionary containing the external fields.
+        tuple: Updated evolved fields list and external field tuple.
     """
 
     field_keys = grab_field_keys(config)
+    external_E, external_B = external_fields
 
     for toml_key in field_keys:
         field_name = config[toml_key]['name']
         field_type = config[toml_key]['type']
         field_path = config[toml_key]['path']
+        evolve = config[toml_key].get('evolve', True)
         print(f"Loading field: {field_name} from {field_path}")
 
         external_field = jnp.load(field_path)
 
         # External fields are (Nx, Ny, Nz), add them to the interior of the ghost-celled arrays
         interior = (slice(1, -1), slice(1, -1), slice(1, -1))
-        interior_shape = fields[field_type][interior].shape
+        if not evolve and (field_type < 0 or field_type > 5):
+            raise ValueError("External-only fields must be electric or magnetic field components with type 0 through 5")
+
+        destination = fields[field_type] if evolve else (external_E + external_B)[field_type]
+        interior_shape = destination[interior].shape
         if external_field.shape != interior_shape:
             raise ValueError(f"Shape mismatch for field '{field_name}': external field shape {external_field.shape} does not match expected interior shape {interior_shape}")
 
-        fields[field_type] = fields[field_type].at[interior].add(external_field)
+        if evolve:
+            # Evolved fields are part of the self-consistent Maxwell solve.
+            # This is the original behavior and remains the default.
+            fields[field_type] = fields[field_type].at[interior].add(external_field)
+        else:
+            # External-only E/B fields are invisible to Maxwell's equations.
+            # They are added back only for particle pushes and diagnostics.
+            if field_type < 3:
+                external_E = list(external_E)
+                external_E[field_type] = external_E[field_type].at[interior].add(external_field)
+                external_E = tuple(external_E)
+            else:
+                external_B = list(external_B)
+                b_index = field_type - 3
+                external_B[b_index] = external_B[b_index].at[interior].add(external_field)
+                external_B = tuple(external_B)
+
         print(f"Field loaded successfully: {field_name}")
 
-    return fields
+    return fields, (external_E, external_B)
 
 def debugprint(value):
     """

--- a/docs/particles.rst
+++ b/docs/particles.rst
@@ -56,6 +56,12 @@ Per-species boundary options:
 
 - ``periodic``
 - ``reflecting``
+- ``absorbing``
+
+Absorbing particle boundaries keep the JAX particle arrays fixed-size and mark
+particles inactive with a species-local mask after they leave the domain.  The
+inactive particles remain allocated for JIT shape stability, but they no longer
+move, push, deposit charge/current, or contribute to particle energy moments.
 
 These are independent from field boundary conditions.
 

--- a/tests/esirkepov_ghost_cells_test.py
+++ b/tests/esirkepov_ghost_cells_test.py
@@ -1,0 +1,84 @@
+import unittest
+
+import jax
+import jax.numpy as jnp
+
+from PyPIC3D.deposition.Esirkepov import (
+    eliminate_esirkepov_ghost_cells,
+    enforce_bc_along_axis,
+)
+
+jax.config.update("jax_enable_x64", True)
+
+
+class TestExtendedEsirkepovGhostCells(unittest.TestCase):
+
+    def test_two_periodic_ghost_layers_fold_to_opposite_interior(self):
+        field = jnp.zeros((8, 3, 3))
+        field = field.at[0, 1, 1].set(1.0)
+        field = field.at[1, 1, 1].set(2.0)
+        field = field.at[-2, 1, 1].set(3.0)
+        field = field.at[-1, 1, 1].set(4.0)
+        field = field.at[2, 1, 1].set(10.0)
+        field = field.at[3, 1, 1].set(20.0)
+        field = field.at[-4, 1, 1].set(30.0)
+        field = field.at[-3, 1, 1].set(40.0)
+
+        folded = enforce_bc_along_axis(field, axis=0, bc="periodic", component_axis=0)
+
+        self.assertAlmostEqual(float(folded[-4, 1, 1]), 31.0)
+        self.assertAlmostEqual(float(folded[-3, 1, 1]), 42.0)
+        self.assertAlmostEqual(float(folded[2, 1, 1]), 13.0)
+        self.assertAlmostEqual(float(folded[3, 1, 1]), 24.0)
+        self.assertEqual(float(folded[0, 1, 1]), 0.0)
+        self.assertEqual(float(folded[1, 1, 1]), 0.0)
+        self.assertEqual(float(folded[-2, 1, 1]), 0.0)
+        self.assertEqual(float(folded[-1, 1, 1]), 0.0)
+
+    def test_two_reflecting_ghost_layers_fold_to_same_side_with_normal_sign(self):
+        field = jnp.zeros((8, 3, 3))
+        field = field.at[0, 1, 1].set(1.0)
+        field = field.at[1, 1, 1].set(2.0)
+        field = field.at[-2, 1, 1].set(3.0)
+        field = field.at[-1, 1, 1].set(4.0)
+        field = field.at[2, 1, 1].set(10.0)
+        field = field.at[3, 1, 1].set(20.0)
+        field = field.at[-4, 1, 1].set(30.0)
+        field = field.at[-3, 1, 1].set(40.0)
+
+        folded = enforce_bc_along_axis(field, axis=0, bc="reflecting", component_axis=0)
+
+        self.assertAlmostEqual(float(folded[2, 1, 1]), 9.0)
+        self.assertAlmostEqual(float(folded[3, 1, 1]), 18.0)
+        self.assertAlmostEqual(float(folded[-4, 1, 1]), 27.0)
+        self.assertAlmostEqual(float(folded[-3, 1, 1]), 36.0)
+
+    def test_two_absorbing_ghost_layers_are_discarded(self):
+        field = jnp.zeros((8, 3, 3))
+        field = field.at[0, 1, 1].set(1.0)
+        field = field.at[1, 1, 1].set(2.0)
+        field = field.at[-2, 1, 1].set(3.0)
+        field = field.at[-1, 1, 1].set(4.0)
+        field = field.at[2, 1, 1].set(10.0)
+        field = field.at[-3, 1, 1].set(40.0)
+
+        folded = enforce_bc_along_axis(field, axis=0, bc="absorbing", component_axis=0)
+
+        self.assertAlmostEqual(float(folded[2, 1, 1]), 10.0)
+        self.assertAlmostEqual(float(folded[-3, 1, 1]), 40.0)
+        self.assertEqual(float(folded[0, 1, 1]), 0.0)
+        self.assertEqual(float(folded[1, 1, 1]), 0.0)
+        self.assertEqual(float(folded[-2, 1, 1]), 0.0)
+        self.assertEqual(float(folded[-1, 1, 1]), 0.0)
+
+    def test_eliminate_esirkepov_ghost_cells_returns_one_ghost_layer(self):
+        field = jnp.arange(8 * 3 * 3, dtype=float).reshape((8, 3, 3))
+
+        restricted = eliminate_esirkepov_ghost_cells(field)
+
+        self.assertEqual(restricted.shape, (6, 1, 1))
+        self.assertTrue(jnp.array_equal(restricted[:, 0, 0], field[1:-1, 1, 1]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/evolve_test.py
+++ b/tests/evolve_test.py
@@ -92,6 +92,73 @@ class TestEvolveExternalFields(unittest.TestCase):
         self.assertTrue(jnp.allclose(B_after[0], 0.0))
         self.assertTrue(jnp.allclose(external_after[0][0], external_fields[0][0]))
 
+    def test_absorbing_particle_mask_survives_jitted_electrodynamic_step(self):
+        world = {
+            "Nx": 3,
+            "Ny": 1,
+            "Nz": 1,
+            "dx": 1.0 / 3.0,
+            "dy": 1.0,
+            "dz": 1.0,
+            "dt": 0.1,
+            "x_wind": 1.0,
+            "y_wind": 1.0,
+            "z_wind": 1.0,
+            "boundary_conditions": {"x": 0, "y": 0, "z": 0},
+        }
+        center_grid, vertex_grid = build_yee_grid(world)
+        world["grids"] = {"center": center_grid, "vertex": vertex_grid}
+        constants = {"C": 10.0, "eps": 1.0, "mu": 1.0, "alpha": 0.0}
+
+        E, B, J, phi, rho = initialize_fields(world["Nx"], world["Ny"], world["Nz"])
+        external_fields = (
+            tuple(jnp.zeros_like(comp) for comp in E),
+            tuple(jnp.zeros_like(comp) for comp in B),
+        )
+        particles = [
+            particle_species(
+                name="absorbing",
+                N_particles=1,
+                charge=1.0,
+                mass=1.0,
+                T=0.0,
+                weight=1.0,
+                v1=jnp.array([0.2]),
+                v2=jnp.array([0.0]),
+                v3=jnp.array([0.0]),
+                x1=jnp.array([0.49]),
+                x2=jnp.array([0.0]),
+                x3=jnp.array([0.0]),
+                xwind=world["x_wind"],
+                ywind=world["y_wind"],
+                zwind=world["z_wind"],
+                dx=world["dx"],
+                dy=world["dy"],
+                dz=world["dz"],
+                x_bc="absorbing",
+                shape=1,
+                dt=world["dt"],
+            )
+        ]
+        fields = (E, B, J, rho, phi, external_fields, None)
+
+        particles, _ = time_loop_electrodynamic(
+            particles,
+            fields,
+            world,
+            constants,
+            unused_curl,
+            zero_current,
+            solver="fdtd",
+            relativistic=False,
+            particle_pusher="boris",
+        )
+
+        x, _, _ = particles[0].get_forward_position()
+
+        self.assertEqual(x.shape[0], 1)
+        self.assertTrue(jnp.array_equal(particles[0].get_active_mask(), jnp.array([False])))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/evolve_test.py
+++ b/tests/evolve_test.py
@@ -67,7 +67,7 @@ class TestEvolveExternalFields(unittest.TestCase):
                 dt=world["dt"],
             )
         ]
-        fields = (E, B, J, rho, phi, external_fields)
+        fields = (E, B, J, rho, phi, external_fields, None)
 
         particles, fields = time_loop_electrodynamic(
             particles,
@@ -81,9 +81,10 @@ class TestEvolveExternalFields(unittest.TestCase):
             particle_pusher="boris",
         )
 
-        E_after, B_after, J_after, rho_after, phi_after, external_after = fields
+        E_after, B_after, J_after, rho_after, phi_after, external_after, pml_state = fields
         vx, vy, vz = particles[0].get_velocity()
 
+        self.assertIsNone(pml_state)
         self.assertGreater(float(vx[0]), 0.0)
         self.assertTrue(jnp.allclose(vy, 0.0))
         self.assertTrue(jnp.allclose(vz, 0.0))

--- a/tests/evolve_test.py
+++ b/tests/evolve_test.py
@@ -1,0 +1,96 @@
+import unittest
+
+import jax
+import jax.numpy as jnp
+
+from PyPIC3D.evolve import time_loop_electrodynamic
+from PyPIC3D.initialization import initialize_fields
+from PyPIC3D.particles.species_class import particle_species
+from PyPIC3D.utils import build_yee_grid
+
+jax.config.update("jax_enable_x64", True)
+
+
+def zero_current(particles, J, constants, world):
+    return tuple(jnp.zeros_like(comp) for comp in J)
+
+
+def unused_curl(Ex, Ey, Ez):
+    return None
+
+
+class TestEvolveExternalFields(unittest.TestCase):
+    def test_external_electric_field_pushes_particles_without_evolving_maxwell_fields(self):
+        world = {
+            "Nx": 3,
+            "Ny": 3,
+            "Nz": 3,
+            "dx": 1.0 / 3.0,
+            "dy": 1.0 / 3.0,
+            "dz": 1.0 / 3.0,
+            "dt": 0.1,
+            "x_wind": 1.0,
+            "y_wind": 1.0,
+            "z_wind": 1.0,
+            "boundary_conditions": {"x": 0, "y": 0, "z": 0},
+        }
+        center_grid, vertex_grid = build_yee_grid(world)
+        world["grids"] = {"center": center_grid, "vertex": vertex_grid}
+        constants = {"C": 10.0, "eps": 1.0, "mu": 1.0, "alpha": 0.0}
+
+        E, B, J, phi, rho = initialize_fields(world["Nx"], world["Ny"], world["Nz"])
+        external_E = tuple(jnp.zeros_like(comp) for comp in E)
+        external_B = tuple(jnp.zeros_like(comp) for comp in B)
+        external_E = (jnp.ones_like(external_E[0]), external_E[1], external_E[2])
+        external_fields = (external_E, external_B)
+
+        particles = [
+            particle_species(
+                name="test",
+                N_particles=1,
+                charge=1.0,
+                mass=1.0,
+                T=0.0,
+                v1=jnp.array([0.0]),
+                v2=jnp.array([0.0]),
+                v3=jnp.array([0.0]),
+                x1=jnp.array([0.0]),
+                x2=jnp.array([0.0]),
+                x3=jnp.array([0.0]),
+                xwind=world["x_wind"],
+                ywind=world["y_wind"],
+                zwind=world["z_wind"],
+                dx=world["dx"],
+                dy=world["dy"],
+                dz=world["dz"],
+                shape=1,
+                dt=world["dt"],
+            )
+        ]
+        fields = (E, B, J, rho, phi, external_fields)
+
+        particles, fields = time_loop_electrodynamic(
+            particles,
+            fields,
+            world,
+            constants,
+            unused_curl,
+            zero_current,
+            solver="fdtd",
+            relativistic=False,
+            particle_pusher="boris",
+        )
+
+        E_after, B_after, J_after, rho_after, phi_after, external_after = fields
+        vx, vy, vz = particles[0].get_velocity()
+
+        self.assertGreater(float(vx[0]), 0.0)
+        self.assertTrue(jnp.allclose(vy, 0.0))
+        self.assertTrue(jnp.allclose(vz, 0.0))
+        self.assertTrue(jnp.allclose(E_after[0], 0.0))
+        self.assertTrue(jnp.allclose(B_after[0], 0.0))
+        self.assertTrue(jnp.allclose(external_after[0][0], external_fields[0][0]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/first_order_yee_test.py
+++ b/tests/first_order_yee_test.py
@@ -161,9 +161,11 @@ class TestFieldsMethods(unittest.TestCase):
         B_initial = (Bx_initial, By_initial, Bz_initial)
         J = (Jx, Jy, Jz)
 
-        Ex_computed, Ey_computed, Ez_computed = update_E(E_initial, B_initial, J, self.world, self.constants, curl_func)
+        E_computed, pml_state = update_E(E_initial, B_initial, J, self.world, self.constants, curl_func)
+        Ex_computed, Ey_computed, Ez_computed = E_computed
 
         # Check shapes (including ghost cells)
+        self.assertIsNone(pml_state)
         self.assertEqual(Ex_computed.shape, (102, 102, 102))
         self.assertEqual(Ey_computed.shape, (102, 102, 102))
         self.assertEqual(Ez_computed.shape, (102, 102, 102))
@@ -240,9 +242,11 @@ class TestFieldsMethods(unittest.TestCase):
         E_initial = (Ex_initial, Ey_initial, Ez_initial)
         B_initial = (Bx_initial, By_initial, Bz_initial)
 
-        Bx_computed, By_computed, Bz_computed = update_B(E_initial, B_initial, self.world, self.constants, curl_func)
+        B_computed, pml_state = update_B(E_initial, B_initial, self.world, self.constants, curl_func)
+        Bx_computed, By_computed, Bz_computed = B_computed
 
         # Check shapes
+        self.assertIsNone(pml_state)
         self.assertEqual(Bx_computed.shape, (102, 102, 102))
         self.assertEqual(By_computed.shape, (102, 102, 102))
         self.assertEqual(Bz_computed.shape, (102, 102, 102))

--- a/tests/openpmd_test.py
+++ b/tests/openpmd_test.py
@@ -85,7 +85,8 @@ class OpenPMDDiagnosticsTests(unittest.TestCase):
         J = _zero_field(shape_with_ghosts)
         rho = jnp.zeros(shape_with_ghosts)
         phi = jnp.zeros(shape_with_ghosts)
-        fields = (E, B, J, rho, phi)
+        external_fields = _zero_field(shape_with_ghosts), _zero_field(shape_with_ghosts)
+        fields = (E, B, J, rho, phi, external_fields)
         world = {
             "dt": 1.0,
             "dx": 0.25,

--- a/tests/openpmd_test.py
+++ b/tests/openpmd_test.py
@@ -1,0 +1,111 @@
+import unittest
+from unittest.mock import patch
+
+import jax.numpy as jnp
+
+from PyPIC3D.diagnostics import openPMD
+from PyPIC3D.diagnostics.openPMD import _ensure_openpmd_array
+
+
+class FakeRecord:
+    def __init__(self):
+        self.shape = None
+        self.unit_SI = None
+
+    def reset_dataset(self, dataset):
+        pass
+
+    def store_chunk(self, array, offset, extent):
+        self.shape = tuple(extent)
+
+
+class FakeMesh:
+    def __init__(self):
+        self.records = {}
+        self.axis_labels = None
+        self.grid_spacing = None
+        self.grid_global_offset = None
+
+    def __getitem__(self, component):
+        if component not in self.records:
+            self.records[component] = FakeRecord()
+        return self.records[component]
+
+
+class FakeMeshes(dict):
+    def __getitem__(self, name):
+        if name not in self:
+            self[name] = FakeMesh()
+        return dict.__getitem__(self, name)
+
+
+class FakeIteration:
+    def __init__(self):
+        self.meshes = FakeMeshes()
+        self.time = None
+        self.dt = None
+        self.time_unit_SI = None
+
+
+class FakeIterations(dict):
+    def __getitem__(self, iteration):
+        if iteration not in self:
+            self[iteration] = FakeIteration()
+        return dict.__getitem__(self, iteration)
+
+
+class FakeSeries:
+    def __init__(self):
+        self.iterations = FakeIterations()
+
+    def flush(self):
+        pass
+
+    def close(self):
+        pass
+
+
+def _zero_field(shape):
+    return tuple(jnp.zeros(shape) for _ in range(3))
+
+
+class OpenPMDDiagnosticsTests(unittest.TestCase):
+
+    def test_openpmd_field_array_preserves_thin_y_axis(self):
+        field_component = jnp.ones((4, 1, 6))
+
+        array = _ensure_openpmd_array(field_component)
+
+        self.assertEqual(array.shape, (4, 1, 6))
+
+    def test_write_openpmd_fields_preserves_thin_y_mesh_metadata(self):
+        shape_with_ghosts = (6, 3, 8)
+        E = _zero_field(shape_with_ghosts)
+        B = _zero_field(shape_with_ghosts)
+        J = _zero_field(shape_with_ghosts)
+        rho = jnp.zeros(shape_with_ghosts)
+        phi = jnp.zeros(shape_with_ghosts)
+        fields = (E, B, J, rho, phi)
+        world = {
+            "dt": 1.0,
+            "dx": 0.25,
+            "dy": 0.5,
+            "dz": 0.75,
+            "x_wind": 1.0,
+            "y_wind": 2.0,
+            "z_wind": 3.0,
+        }
+        series = FakeSeries()
+
+        with patch.object(openPMD, "_open_openpmd_series", return_value=series):
+            openPMD.write_openpmd_fields(fields, world, "/tmp", plot_t=0, t=0)
+
+        B_mesh = series.iterations[0].meshes["B"]
+        self.assertEqual(B_mesh.axis_labels, ["x", "y", "z"])
+        self.assertEqual(B_mesh.grid_spacing, [0.25, 0.5, 0.75])
+        self.assertEqual(B_mesh.grid_global_offset, [-0.5, -1.0, -1.5])
+        self.assertEqual(B_mesh.records["x"].shape, (4, 1, 6))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/openpmd_test.py
+++ b/tests/openpmd_test.py
@@ -1,0 +1,59 @@
+import unittest
+
+import jax.numpy as jnp
+
+from PyPIC3D.diagnostics.openPMD import _fields_to_interior_map
+
+
+def _zero_field(shape):
+    return tuple(jnp.zeros(shape) for _ in range(3))
+
+
+class OpenPMDDiagnosticsTests(unittest.TestCase):
+
+    def test_fields_to_interior_map_skips_empty_pml_state(self):
+        shape = (5, 5, 5)
+        E = _zero_field(shape)
+        B = _zero_field(shape)
+        J = _zero_field(shape)
+        rho = jnp.zeros(shape)
+        phi = jnp.zeros(shape)
+        external_fields = (_zero_field(shape), _zero_field(shape))
+
+        field_map = _fields_to_interior_map((E, B, J, rho, phi, external_fields, None))
+
+        self.assertNotIn("field_1", field_map)
+        self.assertEqual(field_map["rho"].shape, (3, 3, 3))
+
+    def test_fields_to_interior_map_skips_active_pml_memory(self):
+        shape = (5, 5, 5)
+        E = _zero_field(shape)
+        B = _zero_field(shape)
+        J = _zero_field(shape)
+        rho = jnp.zeros(shape)
+        phi = jnp.zeros(shape)
+        external_fields = (_zero_field(shape), _zero_field(shape))
+        pml_state = (_zero_field((3, 3, 3)), _zero_field((3, 3, 3)))
+
+        field_map = _fields_to_interior_map((E, B, J, rho, phi, external_fields, pml_state))
+
+        self.assertNotIn("field_1", field_map)
+
+    def test_fields_to_interior_map_keeps_array_history_fields(self):
+        shape = (5, 5, 5)
+        E = _zero_field(shape)
+        B = _zero_field(shape)
+        J = _zero_field(shape)
+        rho = jnp.zeros(shape)
+        phi = jnp.zeros(shape)
+        external_fields = (_zero_field(shape), _zero_field(shape))
+        A2 = jnp.ones(shape)
+
+        field_map = _fields_to_interior_map((E, B, J, rho, phi, external_fields, A2))
+
+        self.assertIn("field_1", field_map)
+        self.assertEqual(field_map["field_1"].shape, (3, 3, 3))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/particle_test.py
+++ b/tests/particle_test.py
@@ -6,7 +6,8 @@ import os
 
 
 from PyPIC3D.particles.particle_initialization import (
-    initial_particles
+    initial_particles,
+    load_particles_from_toml,
     )
 
 from PyPIC3D.particles.species_class import particle_species
@@ -188,6 +189,117 @@ class TestParticleMethods(unittest.TestCase):
         self.assertTrue(jnp.allclose(y, jnp.array([1.1, 2.2, 3.3])))
         self.assertTrue(jnp.allclose(z, jnp.array([1.1, 2.2, 3.3])))
 
+    def test_absorbing_boundary_updates_active_mask(self):
+        x1 = jnp.array([0.0, self.x_wind / 2 + 0.1, -self.x_wind / 2 - 0.1])
+        x2 = jnp.array([0.0, 0.0, 0.0])
+        x3 = jnp.array([0.0, 0.0, 0.0])
+
+        species = particle_species(
+            name="absorbing",
+            N_particles=self.N_particles,
+            charge=1.0,
+            mass=self.mass,
+            weight=1.0,
+            T=self.T,
+            v1=jnp.array([1.0, 1.0, 1.0]),
+            v2=jnp.array([0.0, 0.0, 0.0]),
+            v3=jnp.array([0.0, 0.0, 0.0]),
+            x1=x1,
+            x2=x2,
+            x3=x3,
+            dx=1.0,
+            dy=1.0,
+            dz=1.0,
+            xwind=self.x_wind,
+            ywind=self.y_wind,
+            zwind=self.z_wind,
+            x_bc="absorbing",
+            dt=self.dt,
+        )
+
+        species.boundary_conditions()
+
+        self.assertTrue(jnp.array_equal(species.get_active_mask(), jnp.array([True, False, False])))
+        self.assertEqual(species.get_forward_position()[0].shape[0], self.N_particles)
+
+    def test_particle_initialization_accepts_absorbing_axis_boundary(self):
+        world = {
+            "Nx": 1,
+            "Ny": 1,
+            "Nz": 1,
+            "dx": 1.0,
+            "dy": 1.0,
+            "dz": 1.0,
+            "dt": self.dt,
+            "x_wind": self.x_wind,
+            "y_wind": self.y_wind,
+            "z_wind": self.z_wind,
+        }
+        constants = {"kb": self.kb, "eps": 1.0}
+        simulation_parameters = {"ds_per_debye": None, "shape_factor": 1}
+        config = {
+            "particle1": {
+                "name": "absorbing",
+                "N_particles": 1,
+                "charge": 1.0,
+                "mass": self.mass,
+                "temperature": self.T,
+                "x_bc": "absorbing",
+                "initial_x": 0.0,
+                "initial_y": 0.0,
+                "initial_z": 0.0,
+                "initial_vx": 0.0,
+                "initial_vy": 0.0,
+                "initial_vz": 0.0,
+            }
+        }
+
+        particles = load_particles_from_toml(config, simulation_parameters, world, constants)
+
+        self.assertEqual(particles[0].x_bc, "absorbing")
+        self.assertTrue(jnp.array_equal(particles[0].get_active_mask(), jnp.array([True])))
+
+    def test_inactive_particles_do_not_advance_or_take_new_velocity(self):
+        species = particle_species(
+            name="absorbing",
+            N_particles=self.N_particles,
+            charge=1.0,
+            mass=self.mass,
+            weight=1.0,
+            T=self.T,
+            v1=jnp.array([1.0, 2.0, 3.0]),
+            v2=jnp.array([0.0, 0.0, 0.0]),
+            v3=jnp.array([0.0, 0.0, 0.0]),
+            x1=jnp.array([0.0, self.x_wind / 2 + 0.1, 0.0]),
+            x2=jnp.array([0.0, 0.0, 0.0]),
+            x3=jnp.array([0.0, 0.0, 0.0]),
+            dx=1.0,
+            dy=1.0,
+            dz=1.0,
+            xwind=self.x_wind,
+            ywind=self.y_wind,
+            zwind=self.z_wind,
+            x_bc="absorbing",
+            dt=self.dt,
+        )
+        species.boundary_conditions()
+
+        species.set_velocity(
+            jnp.array([10.0, 20.0, 30.0]),
+            jnp.array([0.0, 0.0, 0.0]),
+            jnp.array([0.0, 0.0, 0.0]),
+        )
+        species.update_position()
+
+        x, _, _ = species.get_forward_position()
+        vx, _, _ = species.get_velocity()
+
+        self.assertTrue(jnp.array_equal(species.get_active_mask(), jnp.array([True, False, True])))
+        self.assertTrue(jnp.allclose(vx, jnp.array([10.0, 2.0, 30.0])))
+        self.assertTrue(jnp.allclose(x, jnp.array([10.0, self.x_wind / 2 + 0.1, 30.0])))
+        active_vx, _, _ = species.get_active_velocity()
+        self.assertTrue(jnp.allclose(active_vx, jnp.array([10.0, 0.0, 30.0])))
+
     def test_total_KE(self):
         """
         Test the total kinetic energy calculation for a particle species.
@@ -355,6 +467,66 @@ class TestParticleMethods(unittest.TestCase):
         # Jan 12, 2025: Suppressing test for now. I have done benchmarks of the two stream and weibel
         # against WarpX and have validated this method
 
+    def test_inactive_particles_do_not_deposit_rho_or_current(self):
+        Nx, Ny, Nz = 10, 10, 10
+        dx = self.x_wind / Nx
+        dy = self.y_wind / Ny
+        dz = self.z_wind / Nz
+        world = {
+            "dx": dx,
+            "dy": dy,
+            "dz": dz,
+            "Nx": Nx,
+            "Ny": Ny,
+            "Nz": Nz,
+            "x_wind": self.x_wind,
+            "y_wind": self.y_wind,
+            "z_wind": self.z_wind,
+            "dt": 0.0,
+            "boundary_conditions": {"x": 0, "y": 0, "z": 0},
+        }
+        vertex_grid, center_grid = build_yee_grid(world)
+        world["grids"] = {"vertex": vertex_grid, "center": center_grid}
+
+        species = particle_species(
+            name="absorbed",
+            N_particles=1,
+            charge=1.0,
+            mass=self.mass,
+            weight=1.0,
+            T=self.T,
+            v1=jnp.array([0.5]),
+            v2=jnp.array([0.0]),
+            v3=jnp.array([0.0]),
+            x1=jnp.array([self.x_wind / 2 + dx]),
+            x2=jnp.array([0.0]),
+            x3=jnp.array([0.0]),
+            dx=dx,
+            dy=dy,
+            dz=dz,
+            xwind=self.x_wind,
+            ywind=self.y_wind,
+            zwind=self.z_wind,
+            x_bc="absorbing",
+        )
+        species.boundary_conditions()
+
+        constants = {"C": 3e8, "alpha": 1.0}
+        rho = compute_rho([species], jnp.zeros((Nx + 2, Ny + 2, Nz + 2)), world, constants)
+        J = J_from_rhov(
+            [species],
+            (
+                jnp.zeros((Nx + 2, Ny + 2, Nz + 2)),
+                jnp.zeros((Nx + 2, Ny + 2, Nz + 2)),
+                jnp.zeros((Nx + 2, Ny + 2, Nz + 2)),
+            ),
+            constants,
+            world,
+            filter="none",
+        )
+
+        self.assertAlmostEqual(float(jnp.sum(rho[1:-1, 1:-1, 1:-1]) * dx * dy * dz), 0.0)
+        self.assertAlmostEqual(float(jnp.sum(J[0][1:-1, 1:-1, 1:-1]) * dx * dy * dz), 0.0)
 
     def test_rho(self):
         x = jnp.array([0.0])

--- a/tests/pml_test.py
+++ b/tests/pml_test.py
@@ -6,10 +6,9 @@ import jax.numpy as jnp
 
 from PyPIC3D.boundary_conditions.PML import (
     PML_WALLS,
-    build_pml_metadata,
-    build_pml_profiles,
+    build_pml,
     initialize_pml_state,
-    parse_pml_config,
+    load_pml_from_toml,
 )
 from PyPIC3D.initialization import initialize_fields, initialize_simulation
 from PyPIC3D.solvers.first_order_yee import update_B, update_E
@@ -60,52 +59,87 @@ def _empty_config(tmpdir, solver="fdtd", electrostatic=False, pml=None):
 
 
 class TestPMLConfiguration(unittest.TestCase):
-    def test_parse_pml_config_accepts_all_six_walls(self):
+    def test_load_pml_from_toml_accepts_all_six_walls(self):
         raw = [
             {"wall": wall, "thickness": 2, "order": 3.0, "target_reflection": 1e-8}
             for wall in PML_WALLS
         ]
-        parsed = parse_pml_config(raw, _base_world(nx=8, ny=8, nz=8), {"C": 3.0})
 
-        self.assertEqual([entry["wall"] for entry in parsed], PML_WALLS)
-        self.assertTrue(all(entry["sigma_max"] > 0.0 for entry in parsed))
+        active, pml_x, pml_y, pml_z, profiles = load_pml_from_toml(
+            raw,
+            _base_world(nx=8, ny=8, nz=8),
+            {"C": 3.0},
+        )
+        sigma_x, sigma_y, sigma_z = profiles
 
-    def test_parse_pml_config_rejects_invalid_duplicate_and_oversized_walls(self):
+        self.assertTrue(active)
+        self.assertTrue(pml_x)
+        self.assertTrue(pml_y)
+        self.assertTrue(pml_z)
+        self.assertEqual(sigma_x.shape, (10, 10, 10))
+        self.assertTrue(jnp.any(sigma_x > 0.0))
+        self.assertTrue(jnp.any(sigma_y > 0.0))
+        self.assertTrue(jnp.any(sigma_z > 0.0))
+
+    def test_load_pml_from_toml_rejects_invalid_duplicate_and_oversized_walls(self):
         world = _base_world(nx=8, ny=1, nz=1)
 
         with self.assertRaisesRegex(ValueError, "Invalid PML wall"):
-            parse_pml_config([{"wall": "x+", "thickness": 2}], world, {"C": 3.0})
+            load_pml_from_toml([{"wall": "x+", "thickness": 2}], world, {"C": 3.0})
 
         with self.assertRaisesRegex(ValueError, "Duplicate PML wall"):
-            parse_pml_config(
+            load_pml_from_toml(
                 [{"wall": "+x", "thickness": 2}, {"wall": "+x", "thickness": 2}],
                 world,
                 {"C": 3.0},
             )
 
         with self.assertRaisesRegex(ValueError, "exceeds active cells"):
-            parse_pml_config([{"wall": "+x", "thickness": 9}], world, {"C": 3.0})
+            load_pml_from_toml([{"wall": "+x", "thickness": 9}], world, {"C": 3.0})
 
-    def test_build_pml_profiles_ramp_only_on_requested_side(self):
+    def test_build_pml_ramp_only_on_requested_side(self):
         world = _base_world(nx=8, ny=1, nz=1)
-        pml = parse_pml_config(
-            [{"wall": "+x", "thickness": 3, "order": 2.0, "sigma_max": 9.0}],
-            world,
-            {"C": 3.0},
-        )
+        pml_layers = (("+x", "x", 3, 2.0, 9.0),)
 
-        profiles = build_pml_profiles(world, pml)
-        sigma_x = profiles["sigma_x"]
+        sigma_x, sigma_y, sigma_z = build_pml(world, pml_layers)
 
         self.assertEqual(sigma_x.shape, (10, 3, 3))
         self.assertTrue(jnp.allclose(sigma_x[1:5, :, :], 0.0))
         self.assertTrue(jnp.all(sigma_x[-4:-1, :, :] > 0.0))
         self.assertTrue(float(sigma_x[-2, 1, 1]) > float(sigma_x[-4, 1, 1]))
-        self.assertTrue(jnp.allclose(profiles["sigma_y"], 0.0))
-        self.assertTrue(jnp.allclose(profiles["sigma_z"], 0.0))
+        self.assertTrue(jnp.allclose(sigma_y, 0.0))
+        self.assertTrue(jnp.allclose(sigma_z, 0.0))
+
+    def test_build_pml_ramps_from_interior_interface_to_outer_wall(self):
+        world = _base_world(nx=8, ny=1, nz=1)
+        pml_layers = (
+            ("-x", "x", 3, 2.0, 9.0),
+            ("+x", "x", 3, 2.0, 9.0),
+        )
+
+        sigma_x, _, _ = build_pml(world, pml_layers)
+        sigma_x = sigma_x[:, 1, 1]
+
+        self.assertGreater(float(sigma_x[1]), float(sigma_x[2]))
+        self.assertGreater(float(sigma_x[2]), float(sigma_x[3]))
+        self.assertGreater(float(sigma_x[-2]), float(sigma_x[-3]))
+        self.assertGreater(float(sigma_x[-3]), float(sigma_x[-4]))
 
 
 class TestPMLInitialization(unittest.TestCase):
+    def test_initialize_pml_state_uses_physical_interior_shape(self):
+        world = _base_world(nx=8, ny=4, nz=2)
+
+        pml_state = initialize_pml_state(world)
+        e_memory, b_memory = pml_state
+
+        self.assertEqual(len(e_memory), 6)
+        self.assertEqual(len(b_memory), 6)
+        for memory in e_memory:
+            self.assertEqual(memory.shape, (8, 4, 2))
+        for memory in b_memory:
+            self.assertEqual(memory.shape, (8, 4, 2))
+
     def test_initialize_simulation_rejects_pml_for_non_fdtd_solvers(self):
         pml = [{"wall": "+x", "thickness": 2, "sigma_max": 1.0}]
 
@@ -129,28 +163,48 @@ class TestPMLInitialization(unittest.TestCase):
 
         fields = result[2]
         world = result[3]
+        active, pml_x, pml_y, pml_z, _ = world["pml"]
         self.assertEqual(len(fields), 7)
         self.assertIn("pml", world)
-        self.assertTrue(world["pml"]["active"])
+        self.assertTrue(active)
+        self.assertTrue(pml_x)
+        self.assertFalse(pml_y)
+        self.assertFalse(pml_z)
+
+    def test_initialize_simulation_uses_none_pml_state_without_pml_for_fdtd(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = initialize_simulation(_empty_config(tmpdir))
+
+        fields = result[2]
+        world = result[3]
+        active, pml_x, pml_y, pml_z, _ = world["pml"]
+
+        self.assertEqual(len(fields), 7)
+        self.assertIsNone(fields[-1])
+        self.assertFalse(active)
+        self.assertFalse(pml_x)
+        self.assertFalse(pml_y)
+        self.assertFalse(pml_z)
 
 
 class TestPMLFDTDBehavior(unittest.TestCase):
-    def test_no_pml_state_preserves_fdtd_update_signature_and_result(self):
+    def test_no_pml_state_returns_field_and_none_state(self):
         world = _base_world(nx=4, ny=4, nz=4)
         constants = {"C": 2.0, "eps": 1.0, "mu": 1.0, "alpha": 1.0}
         E, B, J, _, _ = initialize_fields(world["Nx"], world["Ny"], world["Nz"])
         B = (B[0], B[1], B[2].at[1:-1, 1:-1, 1:-1].set(1.0))
 
-        E_after = update_E(E, B, J, world, constants, lambda *args: None)
-        B_after = update_B(E_after, B, world, constants, lambda *args: None)
+        E_after, pml_state = update_E(E, B, J, world, constants, lambda *args: None)
+        B_after, pml_state = update_B(E_after, B, world, constants, lambda *args: None, pml_state)
 
         self.assertEqual(len(E_after), 3)
         self.assertEqual(len(B_after), 3)
+        self.assertIsNone(pml_state)
 
     def test_pml_absorbs_field_energy_in_particle_free_1d_wave(self):
         world = _base_world(nx=80, ny=1, nz=1)
         constants = {"C": 1.0, "eps": 1.0, "mu": 1.0, "alpha": 1.0}
-        world["pml"] = build_pml_metadata(
+        world["pml"] = load_pml_from_toml(
             [
                 {"wall": "-x", "thickness": 12, "order": 3.0, "sigma_max": 40.0},
                 {"wall": "+x", "thickness": 12, "order": 3.0, "sigma_max": 40.0},

--- a/tests/pml_test.py
+++ b/tests/pml_test.py
@@ -1,0 +1,184 @@
+import tempfile
+import unittest
+
+import jax
+import jax.numpy as jnp
+
+from PyPIC3D.boundary_conditions.PML import (
+    PML_WALLS,
+    build_pml_metadata,
+    build_pml_profiles,
+    initialize_pml_state,
+    parse_pml_config,
+)
+from PyPIC3D.initialization import initialize_fields, initialize_simulation
+from PyPIC3D.solvers.first_order_yee import update_B, update_E
+from PyPIC3D.utils import build_yee_grid, compute_energy
+
+jax.config.update("jax_enable_x64", True)
+
+
+def _base_world(nx=24, ny=1, nz=1):
+    world = {
+        "Nx": nx,
+        "Ny": ny,
+        "Nz": nz,
+        "dx": 1.0 / nx,
+        "dy": 1.0,
+        "dz": 1.0,
+        "dt": 0.5 / nx,
+        "x_wind": 1.0,
+        "y_wind": 1.0,
+        "z_wind": 1.0,
+        "boundary_conditions": {"x": 0, "y": 0, "z": 0},
+    }
+    center_grid, vertex_grid = build_yee_grid(world)
+    world["grids"] = {"center": center_grid, "vertex": vertex_grid}
+    return world
+
+
+def _empty_config(tmpdir, solver="fdtd", electrostatic=False, pml=None):
+    sim = {
+        "name": "pml init test",
+        "output_dir": tmpdir,
+        "solver": solver,
+        "electrostatic": electrostatic,
+        "Nx": 8,
+        "Ny": 1,
+        "Nz": 1,
+        "x_wind": 1.0,
+        "y_wind": 1.0,
+        "z_wind": 1.0,
+        "Nt": 1,
+        "dt": 1e-10,
+        "fast_backend": "default",
+    }
+    config = {"simulation_parameters": sim, "plotting": {"plotting": False}}
+    if pml is not None:
+        config["pml"] = pml
+    return config
+
+
+class TestPMLConfiguration(unittest.TestCase):
+    def test_parse_pml_config_accepts_all_six_walls(self):
+        raw = [
+            {"wall": wall, "thickness": 2, "order": 3.0, "target_reflection": 1e-8}
+            for wall in PML_WALLS
+        ]
+        parsed = parse_pml_config(raw, _base_world(nx=8, ny=8, nz=8), {"C": 3.0})
+
+        self.assertEqual([entry["wall"] for entry in parsed], PML_WALLS)
+        self.assertTrue(all(entry["sigma_max"] > 0.0 for entry in parsed))
+
+    def test_parse_pml_config_rejects_invalid_duplicate_and_oversized_walls(self):
+        world = _base_world(nx=8, ny=1, nz=1)
+
+        with self.assertRaisesRegex(ValueError, "Invalid PML wall"):
+            parse_pml_config([{"wall": "x+", "thickness": 2}], world, {"C": 3.0})
+
+        with self.assertRaisesRegex(ValueError, "Duplicate PML wall"):
+            parse_pml_config(
+                [{"wall": "+x", "thickness": 2}, {"wall": "+x", "thickness": 2}],
+                world,
+                {"C": 3.0},
+            )
+
+        with self.assertRaisesRegex(ValueError, "exceeds active cells"):
+            parse_pml_config([{"wall": "+x", "thickness": 9}], world, {"C": 3.0})
+
+    def test_build_pml_profiles_ramp_only_on_requested_side(self):
+        world = _base_world(nx=8, ny=1, nz=1)
+        pml = parse_pml_config(
+            [{"wall": "+x", "thickness": 3, "order": 2.0, "sigma_max": 9.0}],
+            world,
+            {"C": 3.0},
+        )
+
+        profiles = build_pml_profiles(world, pml)
+        sigma_x = profiles["sigma_x"]
+
+        self.assertEqual(sigma_x.shape, (10, 3, 3))
+        self.assertTrue(jnp.allclose(sigma_x[1:5, :, :], 0.0))
+        self.assertTrue(jnp.all(sigma_x[-4:-1, :, :] > 0.0))
+        self.assertTrue(float(sigma_x[-2, 1, 1]) > float(sigma_x[-4, 1, 1]))
+        self.assertTrue(jnp.allclose(profiles["sigma_y"], 0.0))
+        self.assertTrue(jnp.allclose(profiles["sigma_z"], 0.0))
+
+
+class TestPMLInitialization(unittest.TestCase):
+    def test_initialize_simulation_rejects_pml_for_non_fdtd_solvers(self):
+        pml = [{"wall": "+x", "thickness": 2, "sigma_max": 1.0}]
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with self.assertRaisesRegex(ValueError, "PML is only supported"):
+                initialize_simulation(_empty_config(tmpdir, solver="spectral", pml=pml))
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with self.assertRaisesRegex(ValueError, "PML is only supported"):
+                initialize_simulation(_empty_config(tmpdir, solver="vector_potential", pml=pml))
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with self.assertRaisesRegex(ValueError, "PML is only supported"):
+                initialize_simulation(_empty_config(tmpdir, electrostatic=True, pml=pml))
+
+    def test_initialize_simulation_appends_pml_state_for_fdtd(self):
+        pml = [{"wall": "+x", "thickness": 2, "sigma_max": 1.0}]
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = initialize_simulation(_empty_config(tmpdir, pml=pml))
+
+        fields = result[2]
+        world = result[3]
+        self.assertEqual(len(fields), 7)
+        self.assertIn("pml", world)
+        self.assertTrue(world["pml"]["active"])
+
+
+class TestPMLFDTDBehavior(unittest.TestCase):
+    def test_no_pml_state_preserves_fdtd_update_signature_and_result(self):
+        world = _base_world(nx=4, ny=4, nz=4)
+        constants = {"C": 2.0, "eps": 1.0, "mu": 1.0, "alpha": 1.0}
+        E, B, J, _, _ = initialize_fields(world["Nx"], world["Ny"], world["Nz"])
+        B = (B[0], B[1], B[2].at[1:-1, 1:-1, 1:-1].set(1.0))
+
+        E_after = update_E(E, B, J, world, constants, lambda *args: None)
+        B_after = update_B(E_after, B, world, constants, lambda *args: None)
+
+        self.assertEqual(len(E_after), 3)
+        self.assertEqual(len(B_after), 3)
+
+    def test_pml_absorbs_field_energy_in_particle_free_1d_wave(self):
+        world = _base_world(nx=80, ny=1, nz=1)
+        constants = {"C": 1.0, "eps": 1.0, "mu": 1.0, "alpha": 1.0}
+        world["pml"] = build_pml_metadata(
+            [
+                {"wall": "-x", "thickness": 12, "order": 3.0, "sigma_max": 40.0},
+                {"wall": "+x", "thickness": 12, "order": 3.0, "sigma_max": 40.0},
+            ],
+            world,
+            constants,
+        )
+        pml_state = initialize_pml_state(world)
+        E, B, J, _, _ = initialize_fields(world["Nx"], world["Ny"], world["Nz"])
+
+        x = world["grids"]["vertex"][0][1:-1]
+        pulse = jnp.exp(-((x + 0.25) / 0.06) ** 2)
+        Ex, Ey, Ez = E
+        Bx, By, Bz = B
+        Ey = Ey.at[1:-1, 1, 1].set(pulse)
+        Bz = Bz.at[1:-1, 1, 1].set(pulse)
+        E = (Ex, Ey, Ez)
+        B = (Bx, By, Bz)
+
+        initial_energy = sum(compute_energy([], E, B, world, constants)[:2])
+        for _ in range(180):
+            E, pml_state = update_E(E, B, J, world, constants, lambda *args: None, pml_state)
+            B, pml_state = update_B(E, B, world, constants, lambda *args: None, pml_state)
+
+        final_energy = sum(compute_energy([], E, B, world, constants)[:2])
+        self.assertTrue(jnp.isfinite(final_energy))
+        self.assertLess(float(final_energy), 0.35 * float(initial_energy))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -1,7 +1,15 @@
 import unittest
+import os
+import tempfile
 import jax
 import jax.numpy as jnp
-from PyPIC3D.utils import print_stats, build_yee_grid, build_collocated_grid, check_stability, particle_sanity_check
+import numpy as np
+from PyPIC3D.initialization import initialize_fields
+from PyPIC3D.utils import (
+    print_stats, build_yee_grid, build_collocated_grid, check_stability,
+    particle_sanity_check, load_external_fields_from_toml, add_external_fields,
+    compute_energy,
+)
 
 jax.config.update("jax_enable_x64", True)
 
@@ -60,6 +68,112 @@ class TestUtilsFunctions(unittest.TestCase):
         # Should not raise
         particle_sanity_check(particles)
         # Check that the particle sanity check does not raise an error
+
+    def test_add_external_fields_adds_components(self):
+        E = (jnp.ones((2, 2, 2)), jnp.ones((2, 2, 2)) * 2, jnp.ones((2, 2, 2)) * 3)
+        B = (jnp.ones((2, 2, 2)) * 4, jnp.ones((2, 2, 2)) * 5, jnp.ones((2, 2, 2)) * 6)
+        external_E = (jnp.ones((2, 2, 2)) * 10, jnp.ones((2, 2, 2)) * 20, jnp.ones((2, 2, 2)) * 30)
+        external_B = (jnp.ones((2, 2, 2)) * 40, jnp.ones((2, 2, 2)) * 50, jnp.ones((2, 2, 2)) * 60)
+
+        total_E, total_B = add_external_fields(E, B, (external_E, external_B))
+
+        self.assertTrue(jnp.allclose(total_E[0], 11.0))
+        self.assertTrue(jnp.allclose(total_E[1], 22.0))
+        self.assertTrue(jnp.allclose(total_E[2], 33.0))
+        self.assertTrue(jnp.allclose(total_B[0], 44.0))
+        self.assertTrue(jnp.allclose(total_B[1], 55.0))
+        self.assertTrue(jnp.allclose(total_B[2], 66.0))
+
+    def test_load_external_fields_defaults_to_evolved_fields(self):
+        E, B, J, phi, rho = initialize_fields(2, 2, 2)
+        fields = [component for field in [E, B, J] for component in field]
+        external_fields = (tuple(jnp.zeros_like(comp) for comp in E), tuple(jnp.zeros_like(comp) for comp in B))
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "ex.npy")
+            np.save(path, np.ones((2, 2, 2)))
+            config = {"field1": {"name": "Ex", "type": 0, "path": path}}
+
+            fields, external_fields = load_external_fields_from_toml(fields, external_fields, config)
+
+        interior = (slice(1, -1), slice(1, -1), slice(1, -1))
+        self.assertTrue(jnp.allclose(fields[0][interior], 1.0))
+        self.assertTrue(jnp.allclose(external_fields[0][0], 0.0))
+
+    def test_load_external_fields_evolve_true_uses_evolved_fields(self):
+        E, B, J, phi, rho = initialize_fields(2, 2, 2)
+        fields = [component for field in [E, B, J] for component in field]
+        external_fields = (tuple(jnp.zeros_like(comp) for comp in E), tuple(jnp.zeros_like(comp) for comp in B))
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "by.npy")
+            np.save(path, np.ones((2, 2, 2)) * 3)
+            config = {"field1": {"name": "By", "type": 4, "path": path, "evolve": True}}
+
+            fields, external_fields = load_external_fields_from_toml(fields, external_fields, config)
+
+        interior = (slice(1, -1), slice(1, -1), slice(1, -1))
+        self.assertTrue(jnp.allclose(fields[4][interior], 3.0))
+        self.assertTrue(jnp.allclose(external_fields[1][1], 0.0))
+
+    def test_load_external_fields_evolve_false_uses_external_fields(self):
+        E, B, J, phi, rho = initialize_fields(2, 2, 2)
+        fields = [component for field in [E, B, J] for component in field]
+        external_fields = (tuple(jnp.zeros_like(comp) for comp in E), tuple(jnp.zeros_like(comp) for comp in B))
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "bz.npy")
+            np.save(path, np.ones((2, 2, 2)) * 5)
+            config = {"field1": {"name": "external Bz", "type": 5, "path": path, "evolve": False}}
+
+            fields, external_fields = load_external_fields_from_toml(fields, external_fields, config)
+
+        interior = (slice(1, -1), slice(1, -1), slice(1, -1))
+        self.assertTrue(jnp.allclose(fields[5][interior], 0.0))
+        self.assertTrue(jnp.allclose(external_fields[1][2][interior], 5.0))
+
+    def test_load_external_fields_rejects_external_current(self):
+        E, B, J, phi, rho = initialize_fields(2, 2, 2)
+        fields = [component for field in [E, B, J] for component in field]
+        external_fields = (tuple(jnp.zeros_like(comp) for comp in E), tuple(jnp.zeros_like(comp) for comp in B))
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "jx.npy")
+            np.save(path, np.ones((2, 2, 2)))
+            config = {"field1": {"name": "external Jx", "type": 6, "path": path, "evolve": False}}
+
+            with self.assertRaisesRegex(ValueError, "External-only fields must be electric or magnetic"):
+                load_external_fields_from_toml(fields, external_fields, config)
+
+    def test_load_external_fields_preserves_shape_validation(self):
+        E, B, J, phi, rho = initialize_fields(2, 2, 2)
+        fields = [component for field in [E, B, J] for component in field]
+        external_fields = (tuple(jnp.zeros_like(comp) for comp in E), tuple(jnp.zeros_like(comp) for comp in B))
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "wrong.npy")
+            np.save(path, np.ones((3, 2, 2)))
+            config = {"field1": {"name": "wrong Ex", "type": 0, "path": path, "evolve": False}}
+
+            with self.assertRaisesRegex(ValueError, "Shape mismatch"):
+                load_external_fields_from_toml(fields, external_fields, config)
+
+    def test_energy_can_include_external_fields(self):
+        E, B, J, phi, rho = initialize_fields(1, 1, 1)
+        external_E = tuple(jnp.zeros_like(comp) for comp in E)
+        external_B = tuple(jnp.zeros_like(comp) for comp in B)
+        interior = (slice(1, -1), slice(1, -1), slice(1, -1))
+        external_E = (external_E[0].at[interior].set(2.0), external_E[1], external_E[2])
+        external_B = (external_B[0], external_B[1].at[interior].set(3.0), external_B[2])
+        total_E, total_B = add_external_fields(E, B, (external_E, external_B))
+
+        world = {"dx": 1.0, "dy": 1.0, "dz": 1.0, "Nx": 1, "Ny": 1, "Nz": 1}
+        constants = {"eps": 2.0, "mu": 4.0, "C": 10.0}
+        e_energy, b_energy, kinetic_energy = compute_energy([], total_E, total_B, world, constants)
+
+        self.assertTrue(jnp.allclose(e_energy, 4.0))
+        self.assertTrue(jnp.allclose(b_energy, 1.125))
+        self.assertEqual(kinetic_energy, 0.0)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -10,6 +10,7 @@ from PyPIC3D.utils import (
     particle_sanity_check, load_external_fields_from_toml, add_external_fields,
     compute_energy,
 )
+from PyPIC3D.particles.species_class import particle_species
 
 jax.config.update("jax_enable_x64", True)
 
@@ -174,6 +175,37 @@ class TestUtilsFunctions(unittest.TestCase):
         self.assertTrue(jnp.allclose(e_energy, 4.0))
         self.assertTrue(jnp.allclose(b_energy, 1.125))
         self.assertEqual(kinetic_energy, 0.0)
+
+    def test_compute_energy_ignores_inactive_particles(self):
+        E, B, J, phi, rho = initialize_fields(1, 1, 1)
+        world = {"dx": 1.0, "dy": 1.0, "dz": 1.0, "Nx": 1, "Ny": 1, "Nz": 1}
+        constants = {"eps": 1.0, "mu": 1.0, "C": 10.0}
+        species = particle_species(
+            name="absorbed",
+            N_particles=1,
+            charge=1.0,
+            mass=1.0,
+            weight=1.0,
+            T=0.0,
+            v1=jnp.array([1.0]),
+            v2=jnp.array([0.0]),
+            v3=jnp.array([0.0]),
+            x1=jnp.array([0.6]),
+            x2=jnp.array([0.0]),
+            x3=jnp.array([0.0]),
+            xwind=1.0,
+            ywind=1.0,
+            zwind=1.0,
+            dx=1.0,
+            dy=1.0,
+            dz=1.0,
+            x_bc="absorbing",
+        )
+        species.boundary_conditions()
+
+        _, _, kinetic_energy = compute_energy([species], E, B, world, constants)
+
+        self.assertTrue(jnp.allclose(kinetic_energy, 0.0))
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
- Adding absorbing bc for particles that actively masks particles on the boundary from particle updates and current deposition.
- Added an Unsplit-Convolutional PML for field boundaries.
-  Identified error in new ghost cell logic for Esirkepov! Forgot to account for additional ghost cell on both boundaries since the second order shape factors can technically have a portion of weight inside the first ghost cell in certain edge cases.

Reference for PML:  Martin, R., & Komatitsch, D. (2009). An unsplit convolutional perfectly matched layer technique improved at grazing incidence for the viscoelastic wave equation. Geophysical Journal International, 179(1), 333-344.